### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
Hi, this seems to be the new line_profiler repo. Pip installing it from source will fail, if cython is not installed:

```
ModuleNotFoundError: No module named 'Cython'
```

This problem can be solved by marking cython as build dependency using a `pyproject.toml` file (PEP 518).

Also see: https://stackoverflow.com/questions/18023546/marking-cython-as-a-build-dependency