### PR TITLE
command-line option to control unit of time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+3.1.2
+~~~~~
+* ENH: Add command line option to specify timer unit
+
 3.0.2
 ~~~~~
 * BUG: fix ``__version__`` attribute in Python 2 CLI.

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-__version__ = '3.0.2'
+__version__ = '3.1.2'
 
 try:
     import cPickle as pickle
@@ -422,7 +422,7 @@ def main():
                                    version=__version__)
 
     parser.add_option('-u', '--unit', default=None,
-                      help="specify the unit of time")
+                      help="specify the 'Timer unit' as a decimal. eg: 1 = seconds, 0.001 or 1e-3 = milliseconds")
 
     options, args = parser.parse_args()
     if len(args) != 1:

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -421,11 +421,25 @@ def main():
     parser = optparse.OptionParser(usage=usage,
                                    version=__version__)
 
+    parser.add_option('-u', '--unit', default=None,
+                      help="specify the unit of time")
+
     options, args = parser.parse_args()
     if len(args) != 1:
         parser.error("Must provide a filename.")
+        
+    output_unit = None
+    try:
+        if options.unit is not None:
+            time_unit = float(options.unit)
+            if time_unit != 0:
+                output_unit = time_unit
+    except:
+        pass
+    
     lstats = load_stats(args[0])
-    show_text(lstats.timings, lstats.unit)
+    show_text(lstats.timings, lstats.unit,
+              output_unit=output_unit)
 
 if __name__ == '__main__':
     main()

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
-pytest >= 3.3.1
-pytest-cov
-coverage >= 4.3.4
+pytest >= 4.6.11
+pytest-cov >= 2.10.1
+coverage >= 5.3
 codecov >= 2.0.15
 ubelt >= 0.8.7


### PR DESCRIPTION
https://github.com/rkern/line_profiler/issues/136#issue-387949622
add a command line option -u --unit to specify the unit of time displayed by line_profiler for ease of use and ease of reading the result.
Windows defaults to 1e-7 whereas specifying 1e-6 would be easier to read and mentally parse.
The user can easily change the unit if the runtimes are expected to be long eg: seconds

eg: to specify a time unit of 1us on the output of kernprof "script.lprof"
python -m line_profiler ./script.lprof -u 1e-6