### PR TITLE
Update pytest and pytest-cov in requirements to fix travis tests

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
-pytest >= 3.3.1
-pytest-cov
-coverage >= 4.3.4
+pytest >= 6.1.2
+pytest-cov >= 2.10.1
+coverage >= 5.3
 codecov >= 2.0.15
 ubelt >= 0.8.7

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
-pytest >= 6.1.2
+pytest >= 4.6.11
 pytest-cov >= 2.10.1
 coverage >= 5.3
 codecov >= 2.0.15


### PR DESCRIPTION
(Please squash this PR) This should fix every PR that fails on 3.5 due to a bad version of pytest installed.