### PR TITLE
Bump versions and add CHANGELOG for recent merge

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+3.1.0
+~~~~~
+* ENH: fix Python 3.9
+* Dropped 3.5 support on Travis
+
 3.0.2
 ~~~~~
 * BUG: fix ``__version__`` attribute in Python 2 CLI.

--- a/README.rst
+++ b/README.rst
@@ -347,7 +347,8 @@ Frequently Asked Questions
 * What version of Python do I need?
 
     Both `line_profiler` and `kernprof` have been tested with Python 2.7, and
-    3.5-3.8.
+    3.6-3.9. Older versions of `line_profiler` support older versions of
+    Python.
 
 
 To Do

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-__version__ = '3.0.2'
+__version__ = '3.1.0'
 
 try:
     import cPickle as pickle


### PR DESCRIPTION
In the recent merge of #31 I forgot to add a CHANGELOG and update the `__version__`. 