### PR TITLE
Update to argparse, improve cli help

### DIFF
--- a/kernprof.py
+++ b/kernprof.py
@@ -162,7 +162,7 @@ def main(args=None):
             raise ArgumentError
         return val
 
-    parser = ArgumentParser()
+    parser = ArgumentParser(description="Run and profile a python script.")
     parser.add_argument('-V', '--version', action='version', version=__version__)
     parser.add_argument('-l', '--line-by-line', action='store_true',
         help="Use the line-by-line profiler instead of cProfile. Implies --builtin.")

--- a/kernprof.py
+++ b/kernprof.py
@@ -4,9 +4,9 @@
 """
 
 import functools
-import optparse
 import os
 import sys
+from argparse import ArgumentError, ArgumentParser
 
 try:
     from line_profiler import __version__
@@ -155,53 +155,46 @@ def find_script(script_name):
     raise SystemExit(1)
 
 
-def main(args=None):
-    def strictly_positive(option, opt, value, parser):
-        if value <= 0:
-            raise optparse.OptionValueError("option %s: floating-point value must be > 0, got %s" % (opt, value))
-        setattr(parser.values, option.dest, value)
+def main():
+    def positive_float(value):
+        val = float(value)
+        if val <= 0:
+            raise ArgumentError
+        return val
 
-    if args is None:
-        args = sys.argv
-    usage = "%prog [-s setupfile] [-o output_file_path] scriptfile [arg] ..."
-    parser = optparse.OptionParser(usage=usage, version=__version__)
-    parser.allow_interspersed_args = False
-    parser.add_option('-l', '--line-by-line', action='store_true',
-        help="Use the line-by-line profiler from the line_profiler module "
-        "instead of Profile. Implies --builtin.")
-    parser.add_option('-b', '--builtin', action='store_true',
-        help="Put 'profile' in the builtins. Use 'profile.enable()' and "
-            "'profile.disable()' in your code to turn it on and off, or "
-            "'@profile' to decorate a single function, or 'with profile:' "
-            "to profile a single section of code.")
-    parser.add_option('-o', '--outfile', default=None,
-        help="Save stats to <outfile>")
-    parser.add_option('-s', '--setup', default=None,
+    parser = ArgumentParser()
+    parser.add_argument('-V', '--version', action='version', version=__version__)
+    parser.add_argument('-l', '--line-by-line', action='store_true',
+        help="Use the line-by-line profiler instead of cProfile. Implies --builtin.")
+    parser.add_argument('-b', '--builtin', action='store_true',
+        help="Put 'profile' in the builtins. Use 'profile.enable()'/'.disable()', "
+            "'@profile' to decorate functions, or 'with profile:' to profile a "
+            "section of code.")
+    parser.add_argument('-o', '--outfile',
+        help="Save stats to <outfile> (default: 'scriptname.lprof' with "
+            "--line-by-line, 'scriptname.prof' without)")
+    parser.add_argument('-s', '--setup',
         help="Code to execute before the code to profile")
-    parser.add_option('-v', '--view', action='store_true',
-        help="View the results of the profile in addition to saving it.")
-    parser.add_option('-u', '--unit', default='1e-6', type=float,
-        action='callback', callback=strictly_positive,
-        help="Output unit (in seconds) in which the timing info is to be "
-            "displayed (for --view). Defaults to 1e-6.")
-    parser.add_option('--skip-zero', action='store_true',
-        help="Hide functions which have not been called (for --view).")
+    parser.add_argument('-v', '--view', action='store_true',
+        help="View the results of the profile in addition to saving it")
+    parser.add_argument('-u', '--unit', default='1e-6', type=positive_float,
+        
+        help="Output unit (in seconds) in which the timing info is "
+        "displayed (default: 1e-6)")
+    parser.add_argument('-z', '--skip-zero', action='store_true',
+        help="Hide functions which have not been called")
 
-    if not sys.argv[1:]:
-        parser.print_usage()
-        sys.exit(2)
+    parser.add_argument('script', help="The python script file to run")
+    parser.add_argument('args', nargs='...', help="Optional script arguments")
 
-    options, args = parser.parse_args()
+    options = parser.parse_args()
 
     if not options.outfile:
-        if options.line_by_line:
-            extension = 'lprof'
-        else:
-            extension = 'prof'
-        options.outfile = '%s.%s' % (os.path.basename(args[0]), extension)
+        extension = 'lprof' if options.line_by_line else 'prof'
+        options.outfile = '%s.%s' % (os.path.basename(options.script), extension)
 
 
-    sys.argv[:] = args
+    sys.argv = [options.script, *options.args]
     if options.setup is not None:
         # Run some setup code outside of the profiler. This is good for large
         # imports.
@@ -227,7 +220,7 @@ def main(args=None):
             import __builtin__ as builtins
         builtins.__dict__['profile'] = prof
 
-    script_file = find_script(sys.argv[0])
+    script_file = find_script(options.script)
     __file__ = script_file
     __name__ = '__main__'
     # Make sure the script's directory is on sys.path instead of just
@@ -250,5 +243,6 @@ def main(args=None):
         if options.view:
             prof.print_stats(output_unit=options.unit, stripzeros=options.skip_zero)
 
+
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    main()

--- a/kernprof.py
+++ b/kernprof.py
@@ -194,7 +194,7 @@ def main(args=None):
         options.outfile = '%s.%s' % (os.path.basename(options.script), extension)
 
 
-    sys.argv = [options.script, *options.args]
+    sys.argv = [options.script] + options.args
     if options.setup is not None:
         # Run some setup code outside of the profiler. This is good for large
         # imports.

--- a/kernprof.py
+++ b/kernprof.py
@@ -155,7 +155,7 @@ def find_script(script_name):
     raise SystemExit(1)
 
 
-def main():
+def main(args=None):
     def positive_float(value):
         val = float(value)
         if val <= 0:
@@ -187,7 +187,7 @@ def main():
     parser.add_argument('script', help="The python script file to run")
     parser.add_argument('args', nargs='...', help="Optional script arguments")
 
-    options = parser.parse_args()
+    options = parser.parse_args(args)
 
     if not options.outfile:
         extension = 'lprof' if options.line_by_line else 'prof'
@@ -245,4 +245,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
Update to argparse because it's better (code, error handling, help, etc), I also changed some help messages and changed the shorthand for `--skip-zero` to `-z` (was `-s` in line_profiler) to be compatible with kernprof.

For comparison, before:

```
> python -m line_profiler
Usage: python -m line_profiler profile.lprof

__main__.py: error: Must provide a filename.
```
```
> python -m line_profiler -h
Usage: python -m line_profiler profile.lprof

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  -u UNIT, --unit=UNIT  Output unit (in seconds) in which the timing info is
                        to be displayed. Defaults to 1e-6.
  -s, --skip-zero       Hide functions which have not been called.
```
```
> kernprof -h
Usage: kernprof [-s setupfile] [-o output_file_path] scriptfile [arg] ...

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  -l, --line-by-line    Use the line-by-line profiler from the line_profiler
                        module instead of Profile. Implies --builtin.
  -b, --builtin         Put 'profile' in the builtins. Use 'profile.enable()'
                        and 'profile.disable()' in your code to turn it on and
                        off, or '@profile' to decorate a single function, or
                        'with profile:' to profile a single section of code.
  -o OUTFILE, --outfile=OUTFILE
                        Save stats to <outfile>
  -s SETUP, --setup=SETUP
                        Code to execute before the code to profile
  -v, --view            View the results of the profile in addition to saving
                        it.
  -u UNIT, --unit=UNIT  Output unit (in seconds) in which the timing info is
                        to be displayed (for --view). Defaults to 1e-6.
  --skip-zero           Hide functions which have not been called (for
                        --view).
```

After:
```
> python -m line_profiler
usage: __main__.py [-h] [-V] [-u UNIT] [-z] profile_output
__main__.py: error: the following arguments are required: profile_output
```
```
> python -m line_profiler -h
usage: __main__.py [-h] [-V] [-u UNIT] [-z] profile_output

positional arguments:
  profile_output        *.lprof file created by kernprof

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -u UNIT, --unit UNIT  Output unit (in seconds) in which the timing info is displayed (default: 1e-6)
  -z, --skip-zero       Hide functions which have not been called
```
```
> kernprof
usage: kernprof [-h] [-V] [-l] [-b] [-o OUTFILE] [-s SETUP] [-v] [-u UNIT] [-z] script ...
kernprof: error: the following arguments are required: script, args
```
```
> kernprof -h
usage: kernprof [-h] [-V] [-l] [-b] [-o OUTFILE] [-s SETUP] [-v] [-u UNIT] [-z] script ...

positional arguments:
  script                The python script file to run
  args                  Optional script arguments

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -l, --line-by-line    Use the line-by-line profiler instead of cProfile. Implies --builtin.
  -b, --builtin         Put 'profile' in the builtins. Use 'profile.enable()'/'.disable()', '@profile' to decorate functions, or 'with profile:' to profile a section of code.
  -o OUTFILE, --outfile OUTFILE
                        Save stats to <outfile> (default: 'scriptname.lprof' with --line-by-line, 'scriptname.prof' without)
  -s SETUP, --setup SETUP
                        Code to execute before the code to profile
  -v, --view            View the results of the profile in addition to saving it
  -u UNIT, --unit UNIT  Output unit (in seconds) in which the timing info is displayed (default: 1e-6)
  -z, --skip-zero       Hide functions which have not been called
```
