### PR TITLE
README: Remove RunSnakeRun (unmaintained)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,13 +241,12 @@ command::
 
     $ python -m pstats script_to_profile.py.prof
 
-Such files may also be viewed with graphical tools like kcachegrind_ through the
-converter program pyprof2calltree_ or RunSnakeRun_.
+Such files may also be viewed with graphical tools like SnakeViz_ and converted
+through pyprof2calltree_ to run on kcachegrind_ and compatible apps.
 
 .. _kcachegrind: http://kcachegrind.sourceforge.net/html/Home.html
 .. _pyprof2calltree: http://pypi.python.org/pypi/pyprof2calltree/
-.. _RunSnakeRun: http://www.vrplumber.com/programming/runsnakerun/
-
+.. _SnakeViz: https://github.com/jiffyclub/snakeviz/
 
 Frequently Asked Questions
 ==========================


### PR DESCRIPTION
Thank you for the project!

I spent a lot of time looking to find out visualizers are hard to come by! Hopefully this can help readers

1. Removes RunSnakeRun (won't run on most systems, not python 3 compatible either, [1](https://stackoverflow.com/a/33121014), [2](https://stackoverflow.com/questions/49790608/runsnakerun-does-not-open-at-all-on-windows))
2. Adds [SnakeViz](https://github.com/jiffyclub/snakeviz/) (which is maintained)
3. Moves visualizers directly compatible with output to the front
4. Easier to read that KCacheGrind and related tools require an extra conversion step