### PR TITLE
Branch for 3.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changes
 3.2.2
 ~~~~~
 * ENH: Added better error message when c-extension is not compiled.
+* FIX: Kernprof no longer imports line_profiler to avoid side effects.
 
 3.2.0
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+3.2.2
+~~~~~
+* ENH: Added better error message when c-extension is not compiled.
+
 3.2.0
 ~~~~~
 * Dropped 2.7 support, manylinux docker images no longer support 2.7 

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ a compiler.  If you wish to use it to run cProfile and not line-by-line
 profiling, you may copy it to a directory on your `PATH` manually and avoid
 trying to build any C extensions.
 
+As of 2021-04-25, only the linux binaries are available on pypi. If you are on
+windows and are unable to build from source, consider using Christoph Gohlke's
+unofficial line-profiler 
+`precompiled win32 wheels <https://www.lfd.uci.edu/~gohlke/pythonlibs/#line_profiler>`_.
+
 .. _git: http://git-scm.com/
 .. _Cython: http://www.cython.org
 .. _build and install: http://docs.python.org/install/index.html

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 line_profiler and kernprof
 --------------------------
 
-|Pypi| |Downloads| |CircleCI| |ActionsTest| |ActionsPublish|
+|Pypi| |Downloads| |CircleCI| |ActionsTest| |ActionsPublish| |Codecov|
 
 
 NOTICE: This is the official `line_profiler` repository. The most recent

--- a/kernprof.py
+++ b/kernprof.py
@@ -8,10 +8,9 @@ import os
 import sys
 from argparse import ArgumentError, ArgumentParser
 
-try:
-    from line_profiler import __version__
-except ImportError:
-    __version__ = 'UNKNOWN'
+# NOTE: This version needs to be manually maintained with the line_profiler
+# __version__ for now.
+__version__ = '3.2.2'
 
 PY3 = sys.version_info[0] == 3
 
@@ -178,7 +177,7 @@ def main(args=None):
     parser.add_argument('-v', '--view', action='store_true',
         help="View the results of the profile in addition to saving it")
     parser.add_argument('-u', '--unit', default='1e-6', type=positive_float,
-        
+
         help="Output unit (in seconds) in which the timing info is "
         "displayed (default: 1e-6)")
     parser.add_argument('-z', '--skip-zero', action='store_true',

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -23,7 +23,13 @@ from IPython.core.page import page
 from IPython.utils.ipstruct import Struct
 from IPython.core.error import UsageError
 
-from ._line_profiler import LineProfiler as CLineProfiler
+try:
+    from ._line_profiler import LineProfiler as CLineProfiler
+except ModuleNotFoundError as ex:
+    raise ModuleNotFoundError(
+        'The line_profiler._line_profiler c-extension module has not '
+        'been compiled. ex={!r}'.format(ex)
+    )
 
 
 def _augment_version(VERSION):
@@ -49,7 +55,7 @@ def _augment_version(VERSION):
     return VERSION
 
 
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 __version__ = _augment_version(__version__)
 
 # Python 2/3 compatibility utils

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,7 @@ def test_version_agreement():
     info1 = ub.cmd('python -m line_profiler --version')
     info2 = ub.cmd('python -m kernprof --version')
 
+    # Strip local version suffixes
     version1 = info1['out'].strip().split('+')[0]
     version2 = info2['out'].strip().split('+')[0]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,3 +46,17 @@ def test_cli():
     # Check for some patterns that should be in the output
     assert '% Time' in info['out']
     assert '7       100' in info['out']
+
+
+def test_version_agreement():
+    """
+    Ensure that line_profiler and kernprof have the same version info
+    """
+    import ubelt as ub
+    info1 = ub.cmd('python -m line_profiler --version')
+    info2 = ub.cmd('python -m kernprof --version')
+
+    version1 = info1['out'].strip().split('+')[0]
+    version2 = info2['out'].strip().split('+')[0]
+
+    assert version2 == version1, 'kernprof and line_profiler must be in sync'


### PR DESCRIPTION
Attempting to fix issues in 3.2.x 

* ENH: Added better error message when c-extension is not compiled.
* FIX: Kernprof no longer imports line_profiler to avoid side effects.


