### PR TITLE
Fix command line option `-v` if used without `-l`

### DIFF
--- a/kernprof.py
+++ b/kernprof.py
@@ -240,7 +240,11 @@ def main(args=None):
         prof.dump_stats(options.outfile)
         print('Wrote profile results to %s' % options.outfile)
         if options.view:
-            prof.print_stats(output_unit=options.unit, stripzeros=options.skip_zero)
+            if isinstance(prof, ContextualProfile):
+                prof.print_stats()
+            else:
+                prof.print_stats(output_unit=options.unit,
+                                 stripzeros=options.skip_zero)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This:

    kernprof -v profile_me.py

Produces this trace back
    Wrote profile results to profile_me.py.prof
    Traceback (most recent call last):
    File ".../bin/kernprof", line 11, in <module>
        sys.exit(main())
    File "...site-packages/kernprof.py", line 243, in main
        prof.print_stats(output_unit=options.unit, stripzeros=options.skip_zero)
    TypeError: print_stats() got an unexpected keyword argument 'output_unit'

While:

    kernprof -v -l profile_me.py

works because the profiler is an instance of a different class.

This patch fixes this problem.