### PR TITLE
Fix missing source in Jupyter notebook/lab

### DIFF
--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -14,6 +14,7 @@ except ImportError:
 import functools
 import inspect
 import linecache
+import tempfile
 import os
 import sys
 from argparse import ArgumentError, ArgumentParser
@@ -194,6 +195,15 @@ class LineProfiler(CLineProfiler):
         return nfuncsadded
 
 
+def is_ipython_kernel_cell(filename):
+    """ Return True if a filename corresponds to a Jupyter Notebook cell
+    """
+    return (
+        filename.startswith("<ipython-input-") or
+        filename.startswith(tempfile.gettempdir() + '/ipykernel_')
+    )
+
+
 def show_func(filename, start_lineno, func_name, timings, unit,
     output_unit=None, stream=None, stripzeros=False):
     """ Show results for a single function.
@@ -217,7 +227,7 @@ def show_func(filename, start_lineno, func_name, timings, unit,
     scalar = unit / output_unit
 
     stream.write("Total time: %g s\n" % (total_time * unit))
-    if os.path.exists(filename) or filename.startswith("<ipython-input-"):
+    if os.path.exists(filename) or is_ipython_kernel_cell(filename):
         stream.write("File: %s\n" % filename)
         stream.write("Function: %s at line %s\n" % (func_name, start_lineno))
         if os.path.exists(filename):


### PR DESCRIPTION
Profiling in Jupyter Notebooks or Jupyter Lab with recent ipykernel
versions (>= 6), resulted in the following error message:

    Could not find file /tmp/ipykernel_8298/3242911465.py
    Are you sure you are running this program from the same
    directory that you ran the profiler from?
    Continuing without the function's contents.

The timing output then does not include source code lines.

The problem is that line_profiler tries to determine when it runs in
side IPython/Jupyter using a simple heuristic based on the reported
filename. New ipykernel versions changed this filename pattern and broke
our test.

As a quick fix, amend the test so it continues working. Longer term, a
more robust solution would be desirable.

Fixes pyutils/line_profiler#86