### PR TITLE
Switch joerick to pypa base for cibuildwheel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,8 +124,9 @@ jobs:
       with:
         platforms: all
 
+    # See: https://github.com/pypa/cibuildwheel/blob/main/action.yml
     - name: Build wheels
-      uses: joerick/cibuildwheel@v1.12.0
+      uses: pypa/cibuildwheel@v1.12.0
       with:
         output-dir: wheelhouse
       # to supply options, put them in 'env', like:


### PR DESCRIPTION
The pypa repo seems like it is more official, so I'm opting to point there, even though it does look like joerick is the lead maintainer.