### PR TITLE
Fix 'ValueError' upon empty linenos variable

### DIFF
--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -203,7 +203,7 @@ def show_func(filename, start_lineno, func_name, timings, unit,
         stream.write('that you ran the profiler from?\n')
         stream.write("Continuing without the function's contents.\n")
         # Fake empty lines so we can see the timings, if not the code.
-        nlines = max(linenos) - min(min(linenos), start_lineno) + 1
+        nlines = 1 if not linenos else max(linenos) - min(min(linenos), start_lineno) + 1
         sublines = [''] * nlines
     for lineno, nhits, time in timings:
         d[lineno] = (nhits,


### PR DESCRIPTION
Profiler crashes in case when linenos is an empty list
'ValueError: max() arg is an empty sequence'

Let's add an extra check for linenos before passing it to a max-function