### PR TITLE
Avoid ZeroDivisionError in rare cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,12 @@ Changes
 3.5.0
 ~~~~~
 * FIX: Fixes max of an empty sequence error #118
+* FIX: #100 Exception raise ZeroDivisionError
 
 3.4.0
 ~~~~~
 * Drop support for Python <= 3.5.x
-* FIX: #104 issue with new IPython kernels 
+* FIX: #104 issue with new IPython kernels
 
 3.3.1
 ~~~~~
@@ -22,7 +23,7 @@ Changes
 3.2.6
 ~~~~~
 * FIX: Update MANIFEST.in to package pyproj.toml and missing pyx file
-* CHANGE: Removed version experimental augmentation. 
+* CHANGE: Removed version experimental augmentation.
 
 3.2.5
 ~~~~~
@@ -44,7 +45,7 @@ Changes
 
 3.2.0
 ~~~~~
-* Dropped 2.7 support, manylinux docker images no longer support 2.7 
+* Dropped 2.7 support, manylinux docker images no longer support 2.7
 * ENH: Add command line option to specify time unit and skip displaying
   functions which have not been profiled.
 * ENH: Unified versions of line_profiler and kernprof: kernprof version is now
@@ -114,4 +115,3 @@ Changes
 ~~~~~
 
 * Initial release.
-

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -206,10 +206,14 @@ def show_func(filename, start_lineno, func_name, timings, unit,
         nlines = 1 if not linenos else max(linenos) - min(min(linenos), start_lineno) + 1
         sublines = [''] * nlines
     for lineno, nhits, time in timings:
+        if total_time == 0:  # Happens rarely on empty function
+            percent = ''
+        else:
+            percent = '%5.1f' % (100 * time / total_time)
         d[lineno] = (nhits,
                      '%5.1f' % (time * scalar),
                      '%5.1f' % (float(time) * scalar / nhits),
-                     '%5.1f' % (100 * time / total_time) )
+                     percent)
     linenos = range(start_lineno, start_lineno + len(sublines))
     empty = ('', '', '', '')
     header = template % ('Line #', 'Hits', 'Time', 'Per Hit', '% Time',


### PR DESCRIPTION
Fixes #100.
Here is a proposition to fix a rare case of ZeroDivisionError in case of empty function. I choose to display no percent value to have a clean output and not displaying wrong values, but it can of course be changed.
This is the result:
```
Total time: 0 s
File: example/profiling_test_script.py
Function: fast at line 59

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    59                                           @profile
    60                                           def fast():
    61         1          0.0      0.0               pass
```

I did not add tests specifically for this, since the total time at zero is non consistent. I can add a specific test calling ``show_func`` directly if needed.

I still have a problem, the tests pass on my machine but not on Github actions, see https://github.com/Nodd/line_profiler/runs/5266057706?check_suite_focus=true
Note that I created other branches (PRs incoming) that fail the same way. I don't think that it comes from my side, can someone check please ?