### PR TITLE
Make IPython optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,12 @@ Changes
 3.5.0
 ~~~~~
 * FIX: Fixes max of an empty sequence error #118
+* Make IPython optional
 
 3.4.0
 ~~~~~
 * Drop support for Python <= 3.5.x
-* FIX: #104 issue with new IPython kernels 
+* FIX: #104 issue with new IPython kernels
 
 3.3.1
 ~~~~~
@@ -22,7 +23,7 @@ Changes
 3.2.6
 ~~~~~
 * FIX: Update MANIFEST.in to package pyproj.toml and missing pyx file
-* CHANGE: Removed version experimental augmentation. 
+* CHANGE: Removed version experimental augmentation.
 
 3.2.5
 ~~~~~
@@ -44,7 +45,7 @@ Changes
 
 3.2.0
 ~~~~~
-* Dropped 2.7 support, manylinux docker images no longer support 2.7 
+* Dropped 2.7 support, manylinux docker images no longer support 2.7
 * ENH: Add command line option to specify time unit and skip displaying
   functions which have not been profiled.
 * ENH: Unified versions of line_profiler and kernprof: kernprof version is now
@@ -114,4 +115,3 @@ Changes
 ~~~~~
 
 * Initial release.
-

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ Releases of `line_profiler` can be installed using pip::
 
     $ pip install line_profiler
 
+Installation while ensuring a compatible IPython version can also be installed using pip::
+
+    $ pip install line_profiler[ipython]
+
 Source releases and any binaries can be downloaded from the PyPI link.
 
     http://pypi.python.org/pypi/line_profiler

--- a/line_profiler/__init__.py
+++ b/line_profiler/__init__.py
@@ -14,17 +14,11 @@ mkinit ./line_profiler/__init__.py --relative -w
 
 from .line_profiler import __version__
 
-from .line_profiler import (LineProfiler,
-                            load_ipython_extension, load_stats, main,
+from .line_profiler import (LineProfiler, load_stats, main,
                             show_func, show_text,)
 
-__all__ = ['LineProfiler', 'line_profiler',
+from .ipython_extension import load_ipython_extension, LineProfilerMagics
+
+__all__ = ['LineProfiler', 'LineProfilerMagics', 'line_profiler',
            'load_ipython_extension', 'load_stats', 'main', 'show_func',
            'show_text', '__version__']
-
-try:
-    from .ipython_extension import LineProfilerMagics
-
-    __all__ += ['LineProfilerMagics']
-except ImportError:
-    pass

--- a/line_profiler/__init__.py
+++ b/line_profiler/__init__.py
@@ -3,6 +3,7 @@ The line_profiler modula for doing line-by-line profiling of functions
 """
 __submodules__ = [
     'line_profiler',
+    'ipython_extension',
 ]
 
 __autogen__ = """
@@ -13,10 +14,16 @@ mkinit ./line_profiler/__init__.py --relative -w
 
 from .line_profiler import __version__
 
-from .line_profiler import (LineProfiler, LineProfilerMagics,
-                            load_ipython_extension, load_stats, main,
+from .line_profiler import (LineProfiler, load_stats, main,
                             show_func, show_text,)
 
-__all__ = ['LineProfiler', 'LineProfilerMagics', 'line_profiler',
-           'load_ipython_extension', 'load_stats', 'main', 'show_func',
+__all__ = ['LineProfiler', 'line_profiler',
+           'load_stats', 'main', 'show_func',
            'show_text', '__version__']
+
+try:
+    from .ipython_extension import (LineProfilerMagics, load_ipython_extension,)
+
+    __all__ += ['LineProfilerMagics', 'load_ipython_extension']
+except ImportError:
+    pass

--- a/line_profiler/__init__.py
+++ b/line_profiler/__init__.py
@@ -14,11 +14,10 @@ mkinit ./line_profiler/__init__.py --relative -w
 
 from .line_profiler import __version__
 
-from .line_profiler import (LineProfiler, load_stats, main,
+from .line_profiler import (LineProfiler,
+                            load_ipython_extension, load_stats, main,
                             show_func, show_text,)
 
-from .ipython_extension import load_ipython_extension, LineProfilerMagics
-
-__all__ = ['LineProfiler', 'LineProfilerMagics', 'line_profiler',
+__all__ = ['LineProfiler', 'line_profiler',
            'load_ipython_extension', 'load_stats', 'main', 'show_func',
            'show_text', '__version__']

--- a/line_profiler/__init__.py
+++ b/line_profiler/__init__.py
@@ -23,7 +23,7 @@ __all__ = ['LineProfiler', 'line_profiler',
            'show_text', '__version__']
 
 try:
-    from .ipython_extension import (LineProfilerMagics, ,)
+    from .ipython_extension import LineProfilerMagics
 
     __all__ += ['LineProfilerMagics']
 except ImportError:

--- a/line_profiler/__init__.py
+++ b/line_profiler/__init__.py
@@ -14,16 +14,17 @@ mkinit ./line_profiler/__init__.py --relative -w
 
 from .line_profiler import __version__
 
-from .line_profiler import (LineProfiler, load_stats, main,
+from .line_profiler import (LineProfiler,
+                            load_ipython_extension, load_stats, main,
                             show_func, show_text,)
 
 __all__ = ['LineProfiler', 'line_profiler',
-           'load_stats', 'main', 'show_func',
+           'load_ipython_extension', 'load_stats', 'main', 'show_func',
            'show_text', '__version__']
 
 try:
-    from .ipython_extension import (LineProfilerMagics, load_ipython_extension,)
+    from .ipython_extension import (LineProfilerMagics, ,)
 
-    __all__ += ['LineProfilerMagics', 'load_ipython_extension']
+    __all__ += ['LineProfilerMagics']
 except ImportError:
     pass

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -1,143 +1,150 @@
 from io import StringIO
 
-from IPython.core.magic import (Magics, magics_class, line_magic)
-from IPython.core.page import page
-from IPython.utils.ipstruct import Struct
-from IPython.core.error import UsageError
-
 from .line_profiler import LineProfiler
 
-
-@magics_class
-class LineProfilerMagics(Magics):
-
-    @line_magic
-    def lprun(self, parameter_s=''):
-        """ Execute a statement under the line-by-line profiler from the
-        line_profiler module.
-
-        Usage:
-          %lprun -f func1 -f func2 <statement>
-
-        The given statement (which doesn't require quote marks) is run via the
-        LineProfiler. Profiling is enabled for the functions specified by the -f
-        options. The statistics will be shown side-by-side with the code through the
-        pager once the statement has completed.
-
-        Options:
-
-        -f <function>: LineProfiler only profiles functions and methods it is told
-        to profile.  This option tells the profiler about these functions. Multiple
-        -f options may be used. The argument may be any expression that gives
-        a Python function or method object. However, one must be careful to avoid
-        spaces that may confuse the option parser.
-
-        -m <module>: Get all the functions/methods in a module
-
-        One or more -f or -m options are required to get any useful results.
-
-        -D <filename>: dump the raw statistics out to a pickle file on disk. The
-        usual extension for this is ".lprof". These statistics may be viewed later
-        by running line_profiler.py as a script.
-
-        -T <filename>: dump the text-formatted statistics with the code side-by-side
-        out to a text file.
-
-        -r: return the LineProfiler object after it has completed profiling.
-
-        -s: strip out all entries from the print-out that have zeros.
-
-        -u: specify time unit for the print-out in seconds.
-        """
-
-        # Escape quote markers.
-        opts_def = Struct(D=[''], T=[''], f=[], m=[], u=None)
-        parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
-        opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:u:', list_all=True)
-        opts.merge(opts_def)
-
-        global_ns = self.shell.user_global_ns
-        local_ns = self.shell.user_ns
-
-        # Get the requested functions.
-        funcs = []
-        for name in opts.f:
-            try:
-                funcs.append(eval(name, global_ns, local_ns))
-            except Exception as e:
-                raise UsageError(f'Could not find module {name}.\n{e.__class__.__name__}: {e}')
-
-        profile = LineProfiler(*funcs)
-
-        # Get the modules, too
-        for modname in opts.m:
-            try:
-                mod = __import__(modname, fromlist=[''])
-                profile.add_module(mod)
-            except Exception as e:
-                raise UsageError(f'Could not find module {modname}.\n{e.__class__.__name__}: {e}')
-
-        if opts.u is not None:
-            try:
-                output_unit = float(opts.u[0])
-            except Exception:
-                raise TypeError('Timer unit setting must be a float.')
-        else:
-            output_unit = None
-
-        # Add the profiler to the builtins for @profile.
-        import builtins
-
-        if 'profile' in builtins.__dict__:
-            had_profile = True
-            old_profile = builtins.__dict__['profile']
-        else:
-            had_profile = False
-            old_profile = None
-        builtins.__dict__['profile'] = profile
-
-        try:
-            try:
-                profile.runctx(arg_str, global_ns, local_ns)
-                message = ''
-            except SystemExit:
-                message = """*** SystemExit exception caught in code being profiled."""
-            except KeyboardInterrupt:
-                message = ('*** KeyboardInterrupt exception caught in code being '
-                           'profiled.')
-        finally:
-            if had_profile:
-                builtins.__dict__['profile'] = old_profile
-
-        # Trap text output.
-        stdout_trap = StringIO()
-        profile.print_stats(stdout_trap, output_unit=output_unit, stripzeros='s' in opts)
-        output = stdout_trap.getvalue()
-        output = output.rstrip()
-
-        page(output)
-        print(message, end='')
-
-        dump_file = opts.D[0]
-        if dump_file:
-            profile.dump_stats(dump_file)
-            print(f'\n*** Profile stats pickled to file {dump_file!r}. {message}')
-
-        text_file = opts.T[0]
-        if text_file:
-            pfile = open(text_file, 'w')
-            pfile.write(output)
-            pfile.close()
-            print(f'\n*** Profile printout saved to text file {text_file!r}. {message}')
-
-        return_value = None
-        if 'r' in opts:
-            return_value = profile
-
-        return return_value
+LineProfilerMagics = None
 
 
 def load_ipython_extension(ip):
     """ API for IPython to recognize this module as an IPython extension.
     """
+
+    # Import IPython inside the function to load IPython only if necessary
+    from IPython.core.magic import (Magics, magics_class, line_magic)
+    from IPython.core.page import page
+    from IPython.utils.ipstruct import Struct
+    from IPython.core.error import UsageError
+
+    # Lazy import
+    global LineProfilerMagics
+
+    @magics_class
+    class LineProfilerMagics(Magics):
+
+        @line_magic
+        def lprun(self, parameter_s=''):
+            """ Execute a statement under the line-by-line profiler from the
+            line_profiler module.
+
+            Usage:
+            %lprun -f func1 -f func2 <statement>
+
+            The given statement (which doesn't require quote marks) is run via the
+            LineProfiler. Profiling is enabled for the functions specified by the -f
+            options. The statistics will be shown side-by-side with the code through the
+            pager once the statement has completed.
+
+            Options:
+
+            -f <function>: LineProfiler only profiles functions and methods it is told
+            to profile.  This option tells the profiler about these functions. Multiple
+            -f options may be used. The argument may be any expression that gives
+            a Python function or method object. However, one must be careful to avoid
+            spaces that may confuse the option parser.
+
+            -m <module>: Get all the functions/methods in a module
+
+            One or more -f or -m options are required to get any useful results.
+
+            -D <filename>: dump the raw statistics out to a pickle file on disk. The
+            usual extension for this is ".lprof". These statistics may be viewed later
+            by running line_profiler.py as a script.
+
+            -T <filename>: dump the text-formatted statistics with the code side-by-side
+            out to a text file.
+
+            -r: return the LineProfiler object after it has completed profiling.
+
+            -s: strip out all entries from the print-out that have zeros.
+
+            -u: specify time unit for the print-out in seconds.
+            """
+
+            # Escape quote markers.
+            opts_def = Struct(D=[''], T=[''], f=[], m=[], u=None)
+            parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
+            opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:u:', list_all=True)
+            opts.merge(opts_def)
+
+            global_ns = self.shell.user_global_ns
+            local_ns = self.shell.user_ns
+
+            # Get the requested functions.
+            funcs = []
+            for name in opts.f:
+                try:
+                    funcs.append(eval(name, global_ns, local_ns))
+                except Exception as e:
+                    raise UsageError(f'Could not find module {name}.\n{e.__class__.__name__}: {e}')
+
+            profile = LineProfiler(*funcs)
+
+            # Get the modules, too
+            for modname in opts.m:
+                try:
+                    mod = __import__(modname, fromlist=[''])
+                    profile.add_module(mod)
+                except Exception as e:
+                    raise UsageError(f'Could not find module {modname}.\n{e.__class__.__name__}: {e}')
+
+            if opts.u is not None:
+                try:
+                    output_unit = float(opts.u[0])
+                except Exception:
+                    raise TypeError('Timer unit setting must be a float.')
+            else:
+                output_unit = None
+
+            # Add the profiler to the builtins for @profile.
+            import builtins
+
+            if 'profile' in builtins.__dict__:
+                had_profile = True
+                old_profile = builtins.__dict__['profile']
+            else:
+                had_profile = False
+                old_profile = None
+            builtins.__dict__['profile'] = profile
+
+            try:
+                try:
+                    profile.runctx(arg_str, global_ns, local_ns)
+                    message = ''
+                except SystemExit:
+                    message = """*** SystemExit exception caught in code being profiled."""
+                except KeyboardInterrupt:
+                    message = ('*** KeyboardInterrupt exception caught in code being '
+                            'profiled.')
+            finally:
+                if had_profile:
+                    builtins.__dict__['profile'] = old_profile
+
+            # Trap text output.
+            stdout_trap = StringIO()
+            profile.print_stats(stdout_trap, output_unit=output_unit, stripzeros='s' in opts)
+            output = stdout_trap.getvalue()
+            output = output.rstrip()
+
+            page(output)
+            print(message, end='')
+
+            dump_file = opts.D[0]
+            if dump_file:
+                profile.dump_stats(dump_file)
+                print(f'\n*** Profile stats pickled to file {dump_file!r}. {message}')
+
+            text_file = opts.T[0]
+            if text_file:
+                pfile = open(text_file, 'w')
+                pfile.write(output)
+                pfile.close()
+                print(f'\n*** Profile printout saved to text file {text_file!r}. {message}')
+
+            return_value = None
+            if 'r' in opts:
+                return_value = profile
+
+            return return_value
+
+    # Register the extension in IPython
     ip.register_magics(LineProfilerMagics)

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -5,6 +5,8 @@ from IPython.core.page import page
 from IPython.utils.ipstruct import Struct
 from IPython.core.error import UsageError
 
+from .line_profiler import LineProfiler
+
 
 @magics_class
 class LineProfilerMagics(Magics):

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -1,0 +1,141 @@
+from io import StringIO
+
+from IPython.core.magic import (Magics, magics_class, line_magic)
+from IPython.core.page import page
+from IPython.utils.ipstruct import Struct
+from IPython.core.error import UsageError
+
+
+@magics_class
+class LineProfilerMagics(Magics):
+
+    @line_magic
+    def lprun(self, parameter_s=''):
+        """ Execute a statement under the line-by-line profiler from the
+        line_profiler module.
+
+        Usage:
+          %lprun -f func1 -f func2 <statement>
+
+        The given statement (which doesn't require quote marks) is run via the
+        LineProfiler. Profiling is enabled for the functions specified by the -f
+        options. The statistics will be shown side-by-side with the code through the
+        pager once the statement has completed.
+
+        Options:
+
+        -f <function>: LineProfiler only profiles functions and methods it is told
+        to profile.  This option tells the profiler about these functions. Multiple
+        -f options may be used. The argument may be any expression that gives
+        a Python function or method object. However, one must be careful to avoid
+        spaces that may confuse the option parser.
+
+        -m <module>: Get all the functions/methods in a module
+
+        One or more -f or -m options are required to get any useful results.
+
+        -D <filename>: dump the raw statistics out to a pickle file on disk. The
+        usual extension for this is ".lprof". These statistics may be viewed later
+        by running line_profiler.py as a script.
+
+        -T <filename>: dump the text-formatted statistics with the code side-by-side
+        out to a text file.
+
+        -r: return the LineProfiler object after it has completed profiling.
+
+        -s: strip out all entries from the print-out that have zeros.
+
+        -u: specify time unit for the print-out in seconds.
+        """
+
+        # Escape quote markers.
+        opts_def = Struct(D=[''], T=[''], f=[], m=[], u=None)
+        parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
+        opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:u:', list_all=True)
+        opts.merge(opts_def)
+
+        global_ns = self.shell.user_global_ns
+        local_ns = self.shell.user_ns
+
+        # Get the requested functions.
+        funcs = []
+        for name in opts.f:
+            try:
+                funcs.append(eval(name, global_ns, local_ns))
+            except Exception as e:
+                raise UsageError(f'Could not find module {name}.\n{e.__class__.__name__}: {e}')
+
+        profile = LineProfiler(*funcs)
+
+        # Get the modules, too
+        for modname in opts.m:
+            try:
+                mod = __import__(modname, fromlist=[''])
+                profile.add_module(mod)
+            except Exception as e:
+                raise UsageError(f'Could not find module {modname}.\n{e.__class__.__name__}: {e}')
+
+        if opts.u is not None:
+            try:
+                output_unit = float(opts.u[0])
+            except Exception:
+                raise TypeError('Timer unit setting must be a float.')
+        else:
+            output_unit = None
+
+        # Add the profiler to the builtins for @profile.
+        import builtins
+
+        if 'profile' in builtins.__dict__:
+            had_profile = True
+            old_profile = builtins.__dict__['profile']
+        else:
+            had_profile = False
+            old_profile = None
+        builtins.__dict__['profile'] = profile
+
+        try:
+            try:
+                profile.runctx(arg_str, global_ns, local_ns)
+                message = ''
+            except SystemExit:
+                message = """*** SystemExit exception caught in code being profiled."""
+            except KeyboardInterrupt:
+                message = ('*** KeyboardInterrupt exception caught in code being '
+                           'profiled.')
+        finally:
+            if had_profile:
+                builtins.__dict__['profile'] = old_profile
+
+        # Trap text output.
+        stdout_trap = StringIO()
+        profile.print_stats(stdout_trap, output_unit=output_unit, stripzeros='s' in opts)
+        output = stdout_trap.getvalue()
+        output = output.rstrip()
+
+        page(output)
+        print(message, end='')
+
+        dump_file = opts.D[0]
+        if dump_file:
+            profile.dump_stats(dump_file)
+            print(f'\n*** Profile stats pickled to file {dump_file!r}. {message}')
+
+        text_file = opts.T[0]
+        if text_file:
+            pfile = open(text_file, 'w')
+            pfile.write(output)
+            pfile.close()
+            print(f'\n*** Profile printout saved to text file {text_file!r}. {message}')
+
+        return_value = None
+        if 'r' in opts:
+            return_value = profile
+
+        return return_value
+
+
+def load_ipython_extension(ip):
+    """ API for IPython to recognize this module as an IPython extension.
+    """
+    ip.register_magics(LineProfilerMagics)

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -1,150 +1,143 @@
 from io import StringIO
 
+from IPython.core.magic import Magics, magics_class, line_magic
+from IPython.core.page import page
+from IPython.utils.ipstruct import Struct
+from IPython.core.error import UsageError
+
 from .line_profiler import LineProfiler
 
-LineProfilerMagics = None
 
+@magics_class
+class LineProfilerMagics(Magics):
+    @line_magic
+    def lprun(self, parameter_s=""):
+        """ Execute a statement under the line-by-line profiler from the
+        line_profiler module.
 
-def load_ipython_extension(ip):
-    """ API for IPython to recognize this module as an IPython extension.
-    """
+        Usage:
+        %lprun -f func1 -f func2 <statement>
 
-    # Import IPython inside the function to load IPython only if necessary
-    from IPython.core.magic import (Magics, magics_class, line_magic)
-    from IPython.core.page import page
-    from IPython.utils.ipstruct import Struct
-    from IPython.core.error import UsageError
+        The given statement (which doesn't require quote marks) is run via the
+        LineProfiler. Profiling is enabled for the functions specified by the -f
+        options. The statistics will be shown side-by-side with the code through the
+        pager once the statement has completed.
 
-    # Lazy import
-    global LineProfilerMagics
+        Options:
 
-    @magics_class
-    class LineProfilerMagics(Magics):
+        -f <function>: LineProfiler only profiles functions and methods it is told
+        to profile.  This option tells the profiler about these functions. Multiple
+        -f options may be used. The argument may be any expression that gives
+        a Python function or method object. However, one must be careful to avoid
+        spaces that may confuse the option parser.
 
-        @line_magic
-        def lprun(self, parameter_s=''):
-            """ Execute a statement under the line-by-line profiler from the
-            line_profiler module.
+        -m <module>: Get all the functions/methods in a module
 
-            Usage:
-            %lprun -f func1 -f func2 <statement>
+        One or more -f or -m options are required to get any useful results.
 
-            The given statement (which doesn't require quote marks) is run via the
-            LineProfiler. Profiling is enabled for the functions specified by the -f
-            options. The statistics will be shown side-by-side with the code through the
-            pager once the statement has completed.
+        -D <filename>: dump the raw statistics out to a pickle file on disk. The
+        usual extension for this is ".lprof". These statistics may be viewed later
+        by running line_profiler.py as a script.
 
-            Options:
+        -T <filename>: dump the text-formatted statistics with the code side-by-side
+        out to a text file.
 
-            -f <function>: LineProfiler only profiles functions and methods it is told
-            to profile.  This option tells the profiler about these functions. Multiple
-            -f options may be used. The argument may be any expression that gives
-            a Python function or method object. However, one must be careful to avoid
-            spaces that may confuse the option parser.
+        -r: return the LineProfiler object after it has completed profiling.
 
-            -m <module>: Get all the functions/methods in a module
+        -s: strip out all entries from the print-out that have zeros.
 
-            One or more -f or -m options are required to get any useful results.
+        -u: specify time unit for the print-out in seconds.
+        """
 
-            -D <filename>: dump the raw statistics out to a pickle file on disk. The
-            usual extension for this is ".lprof". These statistics may be viewed later
-            by running line_profiler.py as a script.
+        # Escape quote markers.
+        opts_def = Struct(D=[""], T=[""], f=[], m=[], u=None)
+        parameter_s = parameter_s.replace('"', r"\"").replace("'", r"\'")
+        opts, arg_str = self.parse_options(parameter_s, "rsf:m:D:T:u:", list_all=True)
+        opts.merge(opts_def)
 
-            -T <filename>: dump the text-formatted statistics with the code side-by-side
-            out to a text file.
+        global_ns = self.shell.user_global_ns
+        local_ns = self.shell.user_ns
 
-            -r: return the LineProfiler object after it has completed profiling.
-
-            -s: strip out all entries from the print-out that have zeros.
-
-            -u: specify time unit for the print-out in seconds.
-            """
-
-            # Escape quote markers.
-            opts_def = Struct(D=[''], T=[''], f=[], m=[], u=None)
-            parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
-            opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:u:', list_all=True)
-            opts.merge(opts_def)
-
-            global_ns = self.shell.user_global_ns
-            local_ns = self.shell.user_ns
-
-            # Get the requested functions.
-            funcs = []
-            for name in opts.f:
-                try:
-                    funcs.append(eval(name, global_ns, local_ns))
-                except Exception as e:
-                    raise UsageError(f'Could not find module {name}.\n{e.__class__.__name__}: {e}')
-
-            profile = LineProfiler(*funcs)
-
-            # Get the modules, too
-            for modname in opts.m:
-                try:
-                    mod = __import__(modname, fromlist=[''])
-                    profile.add_module(mod)
-                except Exception as e:
-                    raise UsageError(f'Could not find module {modname}.\n{e.__class__.__name__}: {e}')
-
-            if opts.u is not None:
-                try:
-                    output_unit = float(opts.u[0])
-                except Exception:
-                    raise TypeError('Timer unit setting must be a float.')
-            else:
-                output_unit = None
-
-            # Add the profiler to the builtins for @profile.
-            import builtins
-
-            if 'profile' in builtins.__dict__:
-                had_profile = True
-                old_profile = builtins.__dict__['profile']
-            else:
-                had_profile = False
-                old_profile = None
-            builtins.__dict__['profile'] = profile
-
+        # Get the requested functions.
+        funcs = []
+        for name in opts.f:
             try:
-                try:
-                    profile.runctx(arg_str, global_ns, local_ns)
-                    message = ''
-                except SystemExit:
-                    message = """*** SystemExit exception caught in code being profiled."""
-                except KeyboardInterrupt:
-                    message = ('*** KeyboardInterrupt exception caught in code being '
-                            'profiled.')
-            finally:
-                if had_profile:
-                    builtins.__dict__['profile'] = old_profile
+                funcs.append(eval(name, global_ns, local_ns))
+            except Exception as e:
+                raise UsageError(
+                    f"Could not find module {name}.\n{e.__class__.__name__}: {e}"
+                )
 
-            # Trap text output.
-            stdout_trap = StringIO()
-            profile.print_stats(stdout_trap, output_unit=output_unit, stripzeros='s' in opts)
-            output = stdout_trap.getvalue()
-            output = output.rstrip()
+        profile = LineProfiler(*funcs)
 
-            page(output)
-            print(message, end='')
+        # Get the modules, too
+        for modname in opts.m:
+            try:
+                mod = __import__(modname, fromlist=[""])
+                profile.add_module(mod)
+            except Exception as e:
+                raise UsageError(
+                    f"Could not find module {modname}.\n{e.__class__.__name__}: {e}"
+                )
 
-            dump_file = opts.D[0]
-            if dump_file:
-                profile.dump_stats(dump_file)
-                print(f'\n*** Profile stats pickled to file {dump_file!r}. {message}')
+        if opts.u is not None:
+            try:
+                output_unit = float(opts.u[0])
+            except Exception:
+                raise TypeError("Timer unit setting must be a float.")
+        else:
+            output_unit = None
 
-            text_file = opts.T[0]
-            if text_file:
-                pfile = open(text_file, 'w')
-                pfile.write(output)
-                pfile.close()
-                print(f'\n*** Profile printout saved to text file {text_file!r}. {message}')
+        # Add the profiler to the builtins for @profile.
+        import builtins
 
-            return_value = None
-            if 'r' in opts:
-                return_value = profile
+        if "profile" in builtins.__dict__:
+            had_profile = True
+            old_profile = builtins.__dict__["profile"]
+        else:
+            had_profile = False
+            old_profile = None
+        builtins.__dict__["profile"] = profile
 
-            return return_value
+        try:
+            try:
+                profile.runctx(arg_str, global_ns, local_ns)
+                message = ""
+            except SystemExit:
+                message = """*** SystemExit exception caught in code being profiled."""
+            except KeyboardInterrupt:
+                message = (
+                    "*** KeyboardInterrupt exception caught in code being " "profiled."
+                )
+        finally:
+            if had_profile:
+                builtins.__dict__["profile"] = old_profile
 
-    # Register the extension in IPython
-    ip.register_magics(LineProfilerMagics)
+        # Trap text output.
+        stdout_trap = StringIO()
+        profile.print_stats(
+            stdout_trap, output_unit=output_unit, stripzeros="s" in opts
+        )
+        output = stdout_trap.getvalue()
+        output = output.rstrip()
+
+        page(output)
+        print(message, end="")
+
+        dump_file = opts.D[0]
+        if dump_file:
+            profile.dump_stats(dump_file)
+            print(f"\n*** Profile stats pickled to file {dump_file!r}. {message}")
+
+        text_file = opts.T[0]
+        if text_file:
+            pfile = open(text_file, "w")
+            pfile.write(output)
+            pfile.close()
+            print(f"\n*** Profile printout saved to text file {text_file!r}. {message}")
+
+        return_value = None
+        if "r" in opts:
+            return_value = profile
+
+        return return_value

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -9,12 +9,6 @@ import sys
 from argparse import ArgumentError, ArgumentParser
 
 try:
-    from ipython_extension import load_ipython_extension
-except ImportError:
-    def load_ipython_extension(ip):
-        raise ImportError("Module IPython not found")
-
-try:
     from ._line_profiler import LineProfiler as CLineProfiler
 except ImportError as ex:
     raise ImportError(

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -155,6 +155,8 @@ class LineProfiler(CLineProfiler):
         return nfuncsadded
 
 
+# This could be in the ipython_extension submodule,
+# but it doesn't depend on the IPython module so it's easier to just let it stay here.
 def is_ipython_kernel_cell(filename):
     """ Return True if a filename corresponds to a Jupyter Notebook cell
     """

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -19,6 +19,13 @@ except ImportError as ex:
 __version__ = '3.5.0'
 
 
+def load_ipython_extension(ip):
+    """ API for IPython to recognize this module as an IPython extension.
+    """
+    from .ipython_extension import LineProfilerMagics
+    ip.register_magics(LineProfilerMagics)
+
+
 def is_coroutine(f):
     return False
 

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -6,13 +6,13 @@ import linecache
 import tempfile
 import os
 import sys
-from io import StringIO
 from argparse import ArgumentError, ArgumentParser
 
-from IPython.core.magic import (Magics, magics_class, line_magic)
-from IPython.core.page import page
-from IPython.utils.ipstruct import Struct
-from IPython.core.error import UsageError
+try:
+    from ipython_extension import load_ipython_extension
+except ImportError:
+    def load_ipython_extension(ip):
+        raise ImportError("Module IPython not found")
 
 try:
     from ._line_profiler import LineProfiler as CLineProfiler
@@ -243,142 +243,6 @@ def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False):
         show_func(fn, lineno, name, stats[fn, lineno, name], unit,
                   output_unit=output_unit, stream=stream,
                   stripzeros=stripzeros)
-
-
-@magics_class
-class LineProfilerMagics(Magics):
-
-    @line_magic
-    def lprun(self, parameter_s=''):
-        """ Execute a statement under the line-by-line profiler from the
-        line_profiler module.
-
-        Usage:
-          %lprun -f func1 -f func2 <statement>
-
-        The given statement (which doesn't require quote marks) is run via the
-        LineProfiler. Profiling is enabled for the functions specified by the -f
-        options. The statistics will be shown side-by-side with the code through the
-        pager once the statement has completed.
-
-        Options:
-
-        -f <function>: LineProfiler only profiles functions and methods it is told
-        to profile.  This option tells the profiler about these functions. Multiple
-        -f options may be used. The argument may be any expression that gives
-        a Python function or method object. However, one must be careful to avoid
-        spaces that may confuse the option parser.
-
-        -m <module>: Get all the functions/methods in a module
-
-        One or more -f or -m options are required to get any useful results.
-
-        -D <filename>: dump the raw statistics out to a pickle file on disk. The
-        usual extension for this is ".lprof". These statistics may be viewed later
-        by running line_profiler.py as a script.
-
-        -T <filename>: dump the text-formatted statistics with the code side-by-side
-        out to a text file.
-
-        -r: return the LineProfiler object after it has completed profiling.
-
-        -s: strip out all entries from the print-out that have zeros.
-
-        -u: specify time unit for the print-out in seconds.
-        """
-
-        # Escape quote markers.
-        opts_def = Struct(D=[''], T=[''], f=[], m=[], u=None)
-        parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
-        opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:u:', list_all=True)
-        opts.merge(opts_def)
-
-        global_ns = self.shell.user_global_ns
-        local_ns = self.shell.user_ns
-
-        # Get the requested functions.
-        funcs = []
-        for name in opts.f:
-            try:
-                funcs.append(eval(name, global_ns, local_ns))
-            except Exception as e:
-                raise UsageError(f'Could not find module {name}.\n{e.__class__.__name__}: {e}')
-
-        profile = LineProfiler(*funcs)
-
-        # Get the modules, too
-        for modname in opts.m:
-            try:
-                mod = __import__(modname, fromlist=[''])
-                profile.add_module(mod)
-            except Exception as e:
-                raise UsageError(f'Could not find module {modname}.\n{e.__class__.__name__}: {e}')
-
-        if opts.u is not None:
-            try:
-                output_unit = float(opts.u[0])
-            except Exception:
-                raise TypeError('Timer unit setting must be a float.')
-        else:
-            output_unit = None
-
-        # Add the profiler to the builtins for @profile.
-        import builtins
-
-        if 'profile' in builtins.__dict__:
-            had_profile = True
-            old_profile = builtins.__dict__['profile']
-        else:
-            had_profile = False
-            old_profile = None
-        builtins.__dict__['profile'] = profile
-
-        try:
-            try:
-                profile.runctx(arg_str, global_ns, local_ns)
-                message = ''
-            except SystemExit:
-                message = """*** SystemExit exception caught in code being profiled."""
-            except KeyboardInterrupt:
-                message = ('*** KeyboardInterrupt exception caught in code being '
-                           'profiled.')
-        finally:
-            if had_profile:
-                builtins.__dict__['profile'] = old_profile
-
-        # Trap text output.
-        stdout_trap = StringIO()
-        profile.print_stats(stdout_trap, output_unit=output_unit, stripzeros='s' in opts)
-        output = stdout_trap.getvalue()
-        output = output.rstrip()
-
-        page(output)
-        print(message, end='')
-
-        dump_file = opts.D[0]
-        if dump_file:
-            profile.dump_stats(dump_file)
-            print(f'\n*** Profile stats pickled to file {dump_file!r}. {message}')
-
-        text_file = opts.T[0]
-        if text_file:
-            pfile = open(text_file, 'w')
-            pfile.write(output)
-            pfile.close()
-            print(f'\n*** Profile printout saved to text file {text_file!r}. {message}')
-
-        return_value = None
-        if 'r' in opts:
-            return_value = profile
-
-        return return_value
-
-
-def load_ipython_extension(ip):
-    """ API for IPython to recognize this module as an IPython extension.
-    """
-    ip.register_magics(LineProfilerMagics)
-
 
 def load_stats(filename):
     """ Utility function to load a pickled LineStats object from a given

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -r requirements/runtime.txt
+-r requirements/ipython.txt
 -r requirements/build.txt
 -r requirements/tests.txt

--- a/requirements/ipython.txt
+++ b/requirements/ipython.txt
@@ -1,0 +1,2 @@
+IPython >=0.13 ; python_version >= '3.7'
+IPython >=0.13, <7.17.0 ; python_version <= '3.6'

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,2 +1,0 @@
-IPython >=0.13 ; python_version >= '3.7'
-IPython >=0.13, <7.17.0 ; python_version <= '3.6'

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,5 @@ pytest >= 4.6.11
 pytest-cov >= 2.10.1
 coverage[toml] >= 5.3
 ubelt >= 1.0.1
+IPython >=0.13 ; python_version >= '3.7'
+IPython >=0.13, <7.17.0 ; python_version <= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,7 @@ if __name__ == '__main__':
         install_requires=parse_requirements('requirements/runtime.txt'),
         extras_require={
             'all': parse_requirements('requirements.txt'),
+            'ipython': parse_requirements('requirements/ipython.txt'),
             'tests': parse_requirements('requirements/tests.txt'),
             'build': parse_requirements('requirements/build.txt'),
         },

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -8,5 +8,14 @@ class TestIPython(unittest.TestCase):
         ip = get_ipython()
         ip.run_line_magic('load_ext', 'line_profiler')
         ip.run_cell(raw_cell='def func():\n    return 2**20')
-        ip.run_line_magic('lprun', '-f func func()')
-        # TODO: Check output
+        lprof = ip.run_line_magic('lprun', '-r -f func func()')
+
+        timings = lprof.get_stats().timings
+        self.assertEqual(len(timings), 1)  # 1 function
+
+        func_data, lines_data = next(iter(timings.items()))
+        self.assertEqual(func_data[1], 1)  # lineno of the function
+        self.assertEqual(func_data[2], "func")  # function name
+        self.assertEqual(len(lines_data), 1)  # 1 line of code
+        self.assertEqual(lines_data[0][0], 2)  # lineno
+        self.assertEqual(lines_data[0][1], 1)  # hits

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -6,7 +6,7 @@ from IPython.testing.globalipapp import get_ipython
 class TestIPython(unittest.TestCase):
     def test_init(self):
         ip = get_ipython()
-        ip.magic('load_ext line_profiler')
-        ip.run_cell(raw_cell="def func():\n    return 2**20")
+        ip.run_line_magic('load_ext', 'line_profiler')
+        ip.run_cell(raw_cell='def func():\n    return 2**20')
         ip.run_line_magic('lprun', '-f func func()')
         # TODO: Check output

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,0 +1,12 @@
+import unittest
+import io
+
+from IPython.testing.globalipapp import get_ipython
+
+class TestIPython(unittest.TestCase):
+    def test_init(self):
+        ip = get_ipython()
+        ip.magic('load_ext line_profiler')
+        ip.run_cell(raw_cell="def func():\n    return 2**20")
+        ip.run_line_magic('lprun', '-f func func()')
+        # TODO: Check output


### PR DESCRIPTION
The only runtime dependency is IPython, which needs many other libraries as well. This make a heavy installation for a features that is completely optional.
It was raised before in https://github.com/rkern/line_profiler/issues/112, with some PR that were never merged, apparently due to lack of time: https://github.com/rkern/line_profiler/pull/139, https://github.com/rkern/line_profiler/pull/114. There is also comments from @rkern that it should be optional: https://github.com/rkern/line_profiler/pull/90
This PR is my take on the subject, since I don't use ipython I had the motivation to get rid of it. It is still an optional dependency for pip, to be able to check the version: ``pip isntall line_profiler[ipython]``

I think that the approach in https://github.com/rkern/line_profiler/pull/139 is better: the IPython import is only made in the ``load_ipython_extension`` call. But since ``LineProfilerMagics`` is added to the "public API" in ``__init__.py`` I couldn't use it easily. The question is, can it be removed or is it needed somewhere ?