### PR TITLE
Stub out version 3.5

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,27 @@
+# For more configuration details:
+# https://docs.codecov.io/docs/codecov-yaml
+
+# Check if this file is valid by running in bash:
+# curl -X POST --data-binary @.codecov.yml https://codecov.io/validate
+
+
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Changes
 =======
 
+3.5.0
+~~~~~
+
 3.4.0
 ~~~~~
 * Drop support for Python <= 3.5.x

--- a/kernprof.py
+++ b/kernprof.py
@@ -9,7 +9,7 @@ from argparse import ArgumentError, ArgumentParser
 
 # NOTE: This version needs to be manually maintained with the line_profiler
 # __version__ for now.
-__version__ = '3.4.0'
+__version__ = '3.5.0'
 
 # Guard the import of cProfile such that 3.x people
 # without lsprof can still use this script.

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -22,7 +22,7 @@ except ImportError as ex:
         f'Has it been compiled? Underlying error is ex={ex!r}'
     )
 
-__version__ = '3.4.0'
+__version__ = '3.5.0'
 
 
 def is_coroutine(f):

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
 pytest >= 4.6.11
 pytest-cov >= 2.10.1
 coverage[toml] >= 5.3
-ubelt >= 0.8.7
+ubelt >= 1.0.1


### PR DESCRIPTION
Bumps `__version__` to '3.5.0' and adds a codecov config. 