### PR TITLE
Warn when adding functions with a __wrapped__ attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changes
 ~~~~~
 * FIX: filepath test in is_ipython_kernel_cell for Windows #161
 * ADD: setup.py now checks LINE_PROFILER_BUILD_METHOD to determine how to build binaries
+* ADD: LineProfiler.add_function warns if an added function has a __wrapped__ attribute
 
 3.5.1
 ~~~~~

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -123,6 +123,13 @@ cdef class LineProfiler:
     def add_function(self, func):
         """ Record line profiling information for the given Python function.
         """
+        if hasattr(func, "__wrapped__"):
+            import warnings
+            warnings.warn(
+                "Adding a function with a __wrapped__ attribute. You may want "
+                "to profile the wrapped function by adding %s.__wrapped__ "
+                "instead." % (func.__name__,)
+            )
         try:
             code = func.__code__
         except AttributeError:


### PR DESCRIPTION
Using `LineProfiler().add_function(decorated_func)` on a decorated function will trace the decorator and not the decorated function. A warning that is raised in the presence of a `__wrapped__` attribute might go a long way in helping users with this edge case already. The `__wrapped__` attribute may be present if [`lru_cache` or `wraps` from `functools`](https://docs.python.org/3/library/functools.html?highlight=__wrapped__) are used. 

See #167.