### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=41.0.1", "wheel>=0.29.0", "Cython>=3.0.0a11"]
+requires = ["setuptools>=41.0.1", "Cython>=3.0.0a11"]
 build-backend = "setuptools.build_meta"  # comment out to disable pep517
 
 [tool.coverage.run]


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a