### PR TITLE
Draft: mark function to profile from the CLI

### DIFF
--- a/line_profiler/imphook.py
+++ b/line_profiler/imphook.py
@@ -1,0 +1,78 @@
+import importlib.abc
+import importlib.machinery
+from pathlib import Path
+import sys
+import ast
+
+class AstModImportHook(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def __init__(self, module_to_monkeypatch):
+        # type: (Dict[str, Callable[[Module], None]) -> None
+        self._modules_to_monkeypatch = {k:None for k in module_to_monkeypatch}
+        self._wl = module_to_monkeypatch
+        self._in_create_module = False
+
+    def find_module(self, fullname, path=None):
+        spec = self.find_spec(fullname, path)
+        if spec is None:
+            return None
+        return spec
+
+    def create_module(self, spec):
+        self._in_create_module = True
+
+        from importlib.util import find_spec, module_from_spec
+        real_spec = importlib.util.find_spec(spec.name)
+
+        real_module = module_from_spec(real_spec)
+        print('RM', real_module.__file__)
+        #real_spec.loader.exec_module(real_module)
+
+        #self._modules_to_monkeypatch[spec.name](real_module)
+
+        self._in_create_module = False
+        return real_module
+
+    def exec_module(self, module):
+        print(module.__name__)
+        if module.__name__ in self._wl:
+            b = ast.parse(Path(module.__file__).read_text())
+            for it in b.body:
+                if isinstance(it, ast.FunctionDef) and (it.name in self._wl[module.__name__]):
+                    print('will profile:', module.__name__, it.name)
+                    it.decorator_list.append(ast.Name(id='profile', ctx=ast.Load()))
+    
+            bp = ast.fix_missing_locations(b)
+            c = compile(bp, module.__name__, 'exec')
+            exec(c, module.__dict__)
+        sys.modules[module.__name__] = module
+        globals()[module.__name__] = module
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname not in self._modules_to_monkeypatch:
+            print('Skip FN', fullname, self._modules_to_monkeypatch)
+            return None
+
+        if self._in_create_module:
+            # if we are in the create_module function,
+            # we return the real module (return None)
+            return None
+        print('Keep FN', fullname)
+        spec = importlib.machinery.ModuleSpec(fullname, self)
+        return spec
+
+def i2():
+    # insert the path hook ahead of other path hooks
+    #sys.path_hooks.insert(0, FileFinder.path_hook(loader_details))
+    
+    # clear any loaders that might already be in use by the FileFinder
+    #sys.path_importer_cache.clear()
+    #invalidate_caches()
+    import builtins
+    def profile(f):
+        f.profile = True
+        return f
+    builtins.profile = profile
+    sys.meta_path.insert(0, AstModImportHook({'click.termui':['clear'], 'rub':['f']}))
+    
+#import pygments.styles
+


### PR DESCRIPTION
This is a draft that allows to profile some function without having to modify the source.

It does so by inserting an importhook that will be active only for module/function pairs that are passed on the command line, and for the given functions it will insert the `@profile` decorator.

The code is not the best, but I'm mostly opening this to get feedback as to whether you believe this is an interesting possibility to push forward, or if it something I should just use for me locally/publish as a separate package.

You can try it with for example

```
$ python -m kernprof -l  --prof bar:f -v line_profiler/foo.py
```

```
$ cat foo.py
from bar import f, g

def main():
    for i in range(60):
        f()
        g()

main()
```
```
$ cat bar.py
import time

def f():
    5
    time.sleep(0.001)
    7

def g():
    pass
```

And you will get the following without having to add the decorator.
```
Timer unit: 1e-06 s

Total time: 0.081675 s
File: /Users/bussonniermatthias/dev/line_profiler/bar.py
Function: f at line 3

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     3                                           def f():
     4        60         37.0      0.6      0.0      5
     5        60      81574.0   1359.6     99.9      time.sleep(0.001)
     6        60         64.0      1.1      0.1      7
```

