### PR TITLE
Add Cython3.0.0b1 compatibility.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ To check out the development sources, you can use Git_::
 You may also download source tarballs of any snapshot from that URL.
 
 Source releases will require a C compiler in order to build `line_profiler`.
-In addition, git checkouts will also require Cython_ >= 0.10. Source releases
+In addition, git checkouts will also require Cython. Source releases
 on PyPI should contain the pregenerated C sources, so Cython should not be
 required in that case.
 
@@ -381,8 +381,7 @@ Frequently Asked Questions
     It should contain the generated C sources already. If you are running into
     problems, that may be a bug; let me know. If you are building from
     a git checkout or snapshot, you will need Cython to generate the
-    C sources. You will probably need version 0.10 or higher. There is a bug in
-    some earlier versions in how it handles NULL PyObject* pointers.
+    C sources.
 
     As of version ``3.0.0`` manylinux wheels containing the binaries are
     available on pypi. Work is still needed to publish osx and win32 wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=41.0.1", "Cython>=3.0.0a11"]
+requires = ["setuptools>=41.0.1", "Cython==3.0.0a11"]
 build-backend = "setuptools.build_meta"  # comment out to disable pep517
 
 [tool.coverage.run]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,5 +1,5 @@
 # Cython is the only hard requirement
-Cython>=3.0.0a11
+Cython==3.0.0a11
 scikit-build>=0.11.1
 cmake>=3.21.2
 ninja>=1.10.2


### PR DESCRIPTION
The latest latest 4.0.2 release of `line_profiler` is broken with `cython==3.0.0b1`, which was released February 25th.  While it is marked as a prerelease on pypi, the declaration of `Cython>=3.0.0a11` added in 380f049f4e776e81785be1d56e7bb92eabd1aa0a means that it now pulls any prerelease after that, which now includes `3.0.0b1` which it does not build with.

This is particularly relevant for anyone installing on OSX, which there are not pre-built wheels -- so it manifests as `pip install line_profiler` failing since February 25th.

@Theelx fixed this as part of #203; however, that is a larger commit series, which may not be easy to merge quickly.  This PR pulls out the one relevant commit from that series and splits out just the `cython==3.0.0b1` compatibility pieces.

Fixes: #204.