### PR TITLE
Fix cython 3.0.0b1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
                     language="c++",
                     define_macros=[("CYTHON_TRACE", (1 if os.getenv("DEV") == "true" else 0))],
                 ),
-                compiler_directives={"language_level": 3, "infer_types": True, "linetrace": (True if os.getenv("DEV") == "true" else False)},
+                compiler_directives={"language_level": 3, "infer_types": True, "linetrace": (True if os.getenv("DEV") == "true" else False), "legacy_implicit_noexcept": True,},
                 include_path=["line_profiler/python25.pxd"],
                 force=force,
                 nthreads=multiprocessing.cpu_count(),


### PR DESCRIPTION
This PR fixes cython 3.0.0b1, and can be merged in addition to #205 if needed. No more API/ABI changes are expected in Cython's prerelease series now that the beta has been hit.