### PR TITLE
Fix text alignment for wide columns in show_func 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+4.0.4
+~~~~
+* FIX: Show text now increases column sizes of hits / time to maintain alignment
+
 4.0.3
 ~~~~
 * FIX: Stop requiring bleeding-edge Cython unless necesasry (for Python 3.12).  #206

--- a/kernprof.py
+++ b/kernprof.py
@@ -11,9 +11,9 @@ import concurrent.futures  # NOQA
 import time
 from argparse import ArgumentError, ArgumentParser
 
-# NOTE: This version needs to be manually maintained with the line_profiler
-# __version__ for now.
-__version__ = '4.0.3'
+# NOTE: This version needs to be manually maintained in
+# line_profiler/line_profiler.py as well
+__version__ = '4.0.4'
 
 # Guard the import of cProfile such that 3.x people
 # without lsprof can still use this script.

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -16,7 +16,8 @@ except ImportError as ex:
         f'Has it been compiled? Underlying error is ex={ex!r}'
     )
 
-__version__ = '4.0.3'
+# NOTE: This needs to be in sync with ../kernprof.py
+__version__ = '4.0.4'
 
 
 def load_ipython_extension(ip):
@@ -206,8 +207,41 @@ def is_ipython_kernel_cell(filename):
 
 def show_func(filename, start_lineno, func_name, timings, unit,
               output_unit=None, stream=None, stripzeros=False):
-    """ Show results for a single function.
     """
+    Show results for a single function.
+
+    Args:
+        filename (str): path to the profiled file
+        start_lineno (int):
+        func_name (str):
+        timings (List[Tuple[int, int, float]])
+        unit (float)
+        output_unit (float | None)
+        stream (io.TextIO | None): defaults to sys.stdout
+        stripzeros (bool)
+
+    Example:
+        >>> from line_profiler.line_profiler import *  # NOQA
+        >>> import line_profiler
+        >>> # Use a function in this file as an example
+        >>> func = line_profiler.line_profiler.show_text
+        >>> start_lineno = func.__code__.co_firstlineno
+        >>> func_lines = list(func.__code__.co_lines())
+        >>> filename = func.__code__.co_filename
+        >>> func_name = func.__name__
+        >>> # Build fake timeings for each line in the example function
+        >>> timings = [
+        >>>     (line_tup[2], idx * 1e13, idx * 2e9)
+        >>>     for idx, line_tup in enumerate(func_lines, start=1)
+        >>> ]
+        >>> unit = 1.0
+        >>> output_unit = 1.0
+        >>> stream = None
+        >>> stripzeros = False
+        >>> show_func(filename, start_lineno, func_name, timings, unit,
+        >>>           output_unit, stream, stripzeros)
+    """
+    import math
     if stream is None:
         stream = sys.stdout
 
@@ -215,9 +249,29 @@ def show_func(filename, start_lineno, func_name, timings, unit,
     d = {}
     total_time = 0.0
     linenos = []
+    max_hits = 0
+    max_time = 0
     for lineno, nhits, time in timings:
         total_time += time
+        max_hits = max(nhits, max_hits)
+        max_time = max(time, max_time)
         linenos.append(lineno)
+
+    # Define how large to make each column so text reasonably fits.
+    column_sizes = {
+        'line': 6,
+        'hits': 9,
+        'time': 12,
+        'perhit': 8,
+        'percent': 8,
+    }
+    col_order = ['line', 'hits', 'time', 'perhit', 'percent']
+    hit_ndigits = int(math.log10(max(max_hits, 1))) + 3
+    time_ndigits = int(math.log10(max(max_time, 1))) + 3
+    column_sizes['hits'] = max(column_sizes['hits'], hit_ndigits)
+    column_sizes['time'] = max(column_sizes['time'], time_ndigits)
+    template = ' '.join(['%' + str(column_sizes[k]) + 's' for k in col_order])
+    template = template + '  %-s'
 
     if stripzeros and total_time == 0:
         return

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -212,13 +212,13 @@ def show_func(filename, start_lineno, func_name, timings, unit,
 
     Args:
         filename (str): path to the profiled file
-        start_lineno (int):
-        func_name (str):
-        timings (List[Tuple[int, int, float]])
-        unit (float)
-        output_unit (float | None)
+        start_lineno (int): first line number of profiled function
+        func_name (str): name of profiled function
+        timings (List[Tuple[int, int, float]]): measurements for each line
+        unit (float):
+        output_unit (float | None):
         stream (io.TextIO | None): defaults to sys.stdout
-        stripzeros (bool)
+        stripzeros (bool):
 
     Example:
         >>> from line_profiler.line_profiler import *  # NOQA

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,3 +4,4 @@ coverage[toml] >= 5.3
 ubelt >= 1.0.1
 IPython >=0.13 ; python_version >= '3.7'
 IPython >=0.13, <7.17.0 ; python_version <= '3.6'
+xdoctest >= 1.1.1


### PR DESCRIPTION
I added some logic in `show_func` to widen columns if necessary. I also added an associated doctest that demonstrates the issue.

Before when hits or time was large enough it would overflow the column and make the lines have bad indentation:

```python
Total time: 1.32e+11 s
File: /home/joncrall/code/line_profiler/line_profiler/line_profiler.py
Function: show_text at line 306

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   306                                           def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False):
   307                                               """ Show text for the given timings.
   308                                               """
   309 100000000.0 2000000000.0     20.0      1.5      if stream is None:
   310 200000000.0 4000000000.0     20.0      3.0          stream = sys.stdout
   311                                           
   312 300000000.0 6000000000.0     20.0      4.5      if output_unit is not None:
   313 400000000.0 8000000000.0     20.0      6.1          stream.write('Timer unit: %g s\n\n' % output_unit)
   314                                               else:
   315 500000000.0 10000000000.0     20.0      7.6          stream.write('Timer unit: %g s\n\n' % unit)
   316                                           
   317 1100000000.0 22000000000.0     20.0     16.7      for (fn, lineno, name), timings in sorted(stats.items()):
   318 1000000000.0 20000000000.0     20.0     15.2          show_func(fn, lineno, name, stats[fn, lineno, name], unit,
   319 800000000.0 16000000000.0     20.0     12.1                    output_unit=output_unit, stream=stream,
   320 900000000.0 18000000000.0     20.0     13.6                    stripzeros=stripzeros)
```

With the fix the column width increases to accomidate the largest number in the column:

```python
Total time: 1.32e+11 s
File: /home/joncrall/code/line_profiler/line_profiler/line_profiler.py
Function: show_text at line 327

Line #              Hits          Time  Per Hit   % Time  Line Contents
=======================================================================
   327                                                    def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False):
   328                                                        """ Show text for the given timings.
   329                                                        """
   330  10000000000000.0  2000000000.0      0.0      1.5      if stream is None:
   331  20000000000000.0  4000000000.0      0.0      3.0          stream = sys.stdout
   332                                                    
   333  30000000000000.0  6000000000.0      0.0      4.5      if output_unit is not None:
   334  40000000000000.0  8000000000.0      0.0      6.1          stream.write('Timer unit: %g s\n\n' % output_unit)
   335                                                        else:
   336  50000000000000.0 10000000000.0      0.0      7.6          stream.write('Timer unit: %g s\n\n' % unit)
   337                                                    
   338 110000000000000.0 22000000000.0      0.0     16.7      for (fn, lineno, name), timings in sorted(stats.items()):
   339 100000000000000.0 20000000000.0      0.0     15.2          show_func(fn, lineno, name, stats[fn, lineno, name], unit,
   340  80000000000000.0 16000000000.0      0.0     12.1                    output_unit=output_unit, stream=stream,
   341  90000000000000.0 18000000000.0      0.0     13.6                    stripzeros=stripzeros)
```
