### PR TITLE
Column Fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@ Changes
 
 4.0.4
 ~~~~
-* FIX: Show text now increases column sizes of hits / time to maintain alignment
+* FIX: `show_text` now increases column sizes or switches to scientific notation to maintain alignment
+* ENH: `show_text` now has new options: sort and summarize
 
 4.0.3
 ~~~~

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -235,18 +235,20 @@ def show_func(filename, start_lineno, func_name, timings, unit,
             if True, prints nothing if the function was not run
 
     Example:
-        >>> from line_profiler.line_profiler import *  # NOQA
+        >>> from line_profiler.line_profiler import show_func
         >>> import line_profiler
         >>> # Use a function in this file as an example
         >>> func = line_profiler.line_profiler.show_text
         >>> start_lineno = func.__code__.co_firstlineno
-        >>> func_lines = list(func.__code__.co_lines())
         >>> filename = func.__code__.co_filename
         >>> func_name = func.__name__
         >>> # Build fake timeings for each line in the example function
+        >>> import inspect
+        >>> num_lines = len(inspect.getsourcelines(func)[0])
+        >>> line_numbers = list(range(start_lineno + 3, start_lineno + num_lines))
         >>> timings = [
-        >>>     (line_tup[2], idx * 1e13, idx * (2e10 ** (idx % 3)))
-        >>>     for idx, line_tup in enumerate(func_lines, start=1)
+        >>>     (lineno, idx * 1e13, idx * (2e10 ** (idx % 3)))
+        >>>     for idx, lineno in enumerate(line_numbers, start=1)
         >>> ]
         >>> unit = 1.0
         >>> output_unit = 1.0
@@ -295,7 +297,7 @@ def show_func(filename, start_lineno, func_name, timings, unit,
         'percent': 8,
     }
 
-    ALLOW_SCIENTIFIC_NOTATION = 0
+    ALLOW_SCIENTIFIC_NOTATION = 1
     col_order = ['line', 'hits', 'time', 'perhit', 'percent']
     template = '%6s %9s %12s %8s %8s  %-s'
 

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -298,13 +298,10 @@ def show_func(filename, start_lineno, func_name, timings, unit,
     }
 
     ALLOW_SCIENTIFIC_NOTATION = 1
-    col_order = ['line', 'hits', 'time', 'perhit', 'percent']
-    template = '%6s %9s %12s %8s %8s  %-s'
-
     display = {}
 
     # Loop over each line to determine better column formatting.
-    # Fallback to scientific notation if columns are larger.
+    # Fallback to scientific notation if columns are larger than a threshold.
     for lineno, nhits, time in timings:
         if total_time == 0:  # Happens rarely on empty function
             percent = ''
@@ -312,28 +309,31 @@ def show_func(filename, start_lineno, func_name, timings, unit,
             percent = '%5.1f' % (100 * time / total_time)
 
         time_disp = '%5.1f' % (time * scalar)
-        if len(time_disp) > default_column_sizes['time'] and ALLOW_SCIENTIFIC_NOTATION:
+        if ALLOW_SCIENTIFIC_NOTATION and len(time_disp) > default_column_sizes['time']:
             time_disp = '%5.1g' % (time * scalar)
 
         perhit_disp = '%5.1f' % (float(time) * scalar / nhits)
-        if len(perhit_disp) > default_column_sizes['perhit'] and ALLOW_SCIENTIFIC_NOTATION:
+        if ALLOW_SCIENTIFIC_NOTATION and len(perhit_disp) > default_column_sizes['perhit']:
             perhit_disp = '%5.1g' % (float(time) * scalar / nhits)
 
         nhits_disp = "%d" % nhits
-        if len(nhits_disp) > default_column_sizes['hits'] and ALLOW_SCIENTIFIC_NOTATION:
+        if ALLOW_SCIENTIFIC_NOTATION and len(nhits_disp) > default_column_sizes['hits']:
             nhits_disp = '%g' % nhits
 
         display[lineno] = (nhits_disp, time_disp, perhit_disp, percent)
 
-    max_hitlen = max(len(t[0]) for t in display.values())
-    max_timelen = max(len(t[1]) for t in display.values())
-    max_perhitlen = max(len(t[2]) for t in display.values())
-
     # Expand column sizes if the numbers are large.
     column_sizes = default_column_sizes.copy()
-    column_sizes['hits'] = max(column_sizes['hits'], max_hitlen)
-    column_sizes['time'] = max(column_sizes['time'], max_timelen)
-    column_sizes['perhit'] = max(column_sizes['perhit'], max_perhitlen)
+    if len(display):
+        max_hitlen = max(len(t[0]) for t in display.values())
+        max_timelen = max(len(t[1]) for t in display.values())
+        max_perhitlen = max(len(t[2]) for t in display.values())
+        column_sizes['hits'] = max(column_sizes['hits'], max_hitlen)
+        column_sizes['time'] = max(column_sizes['time'], max_timelen)
+        column_sizes['perhit'] = max(column_sizes['perhit'], max_perhitlen)
+
+    # template = '%6s %9s %12s %8s %8s  %-s'
+    col_order = ['line', 'hits', 'time', 'perhit', 'percent']
     template = ' '.join(['%' + str(column_sizes[k]) + 's' for k in col_order])
     template = template + '  %-s'
 

--- a/tests/complex_example.py
+++ b/tests/complex_example.py
@@ -1,0 +1,121 @@
+"""
+A script used in test_complex_case.py
+"""
+import line_profiler
+import atexit
+
+
+profile = line_profiler.LineProfiler()
+
+
+@atexit.register
+def _show_profile_on_end():
+    profile.print_stats()
+
+
+@profile
+def fib(n):
+    a, b = 0, 1
+    while a < n:
+        print(a, end=' ')
+        a, b = b, a + b
+    print()
+
+
+@profile
+def funcy_fib(n):
+    """
+    Alternatite fib function where code splits out over multiple lines
+    """
+    a, b = (
+        0, 1
+    )
+    while a < n:
+        print(
+            a, end=' ')
+        a, b = b, \
+                a + b
+    print(
+    )
+
+
+@profile
+def fib_only_called_by_thread(n):
+    a, b = 0, 1
+    while a < n:
+        print(a, end=' ')
+        a, b = b, a + b
+    print()
+
+
+@profile
+def fib_only_called_by_process(n):
+    a, b = 0, 1
+    while a < n:
+        print(a, end=' ')
+        a, b = b, a + b
+    # FIXME: having two functions with the EXACT same code can cause issues
+    # a = 'no longer exactly the same'
+    print()
+
+
+@profile
+def main():
+    """
+    Run a lot of different Fibonacci jobs
+    """
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--size', type=int, default=10)
+    args = parser.parse_args()
+
+    size = args.size
+
+    for i in range(size):
+        fib(i)
+        funcy_fib(
+            i)
+        fib(i)
+
+    from concurrent.futures import ThreadPoolExecutor
+    executor = ThreadPoolExecutor(max_workers=4)
+    with executor:
+        jobs = []
+        for i in range(size):
+            job = executor.submit(fib, i)
+            jobs.append(job)
+
+            job = executor.submit(funcy_fib, i)
+            jobs.append(job)
+
+            job = executor.submit(fib_only_called_by_thread, i)
+            jobs.append(job)
+
+        for job in jobs:
+            job.result()
+
+    from concurrent.futures import ProcessPoolExecutor
+    executor = ProcessPoolExecutor(max_workers=4)
+    with executor:
+        jobs = []
+        for i in range(size):
+            job = executor.submit(fib, i)
+            jobs.append(job)
+
+            job = executor.submit(funcy_fib, i)
+            jobs.append(job)
+
+            job = executor.submit(fib_only_called_by_process, i)
+            jobs.append(job)
+
+        for job in jobs:
+            job.result()
+
+
+if __name__ == '__main__':
+    """
+    CommandLine:
+        cd ~/code/line_profiler/tests/
+        python complex_example.py --size 10
+    """
+    main()

--- a/tests/complex_example.py
+++ b/tests/complex_example.py
@@ -10,53 +10,30 @@ profile = line_profiler.LineProfiler()
 
 @atexit.register
 def _show_profile_on_end():
-    profile.print_stats()
+    profile.print_stats(summarize=1, sort=1, stripzeros=1)
 
 
 @profile
 def fib(n):
     a, b = 0, 1
     while a < n:
-        print(a, end=' ')
         a, b = b, a + b
-    print()
-
-
-@profile
-def funcy_fib(n):
-    """
-    Alternatite fib function where code splits out over multiple lines
-    """
-    a, b = (
-        0, 1
-    )
-    while a < n:
-        print(
-            a, end=' ')
-        a, b = b, \
-                a + b
-    print(
-    )
 
 
 @profile
 def fib_only_called_by_thread(n):
     a, b = 0, 1
     while a < n:
-        print(a, end=' ')
         a, b = b, a + b
-    print()
 
 
 @profile
 def fib_only_called_by_process(n):
     a, b = 0, 1
     while a < n:
-        print(a, end=' ')
         a, b = b, a + b
     # FIXME: having two functions with the EXACT same code can cause issues
-    # a = 'no longer exactly the same'
-    print()
+    a = 'no longer exactly the same'
 
 
 @profile
@@ -66,12 +43,12 @@ def main():
     """
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('--size', type=int, default=10)
+    parser.add_argument('--serial_size', type=int, default=10)
+    parser.add_argument('--thread_size', type=int, default=10)
+    parser.add_argument('--process_size', type=int, default=10)
     args = parser.parse_args()
 
-    size = args.size
-
-    for i in range(size):
+    for i in range(args.serial_size):
         fib(i)
         funcy_fib(
             i)
@@ -81,7 +58,7 @@ def main():
     executor = ThreadPoolExecutor(max_workers=4)
     with executor:
         jobs = []
-        for i in range(size):
+        for i in range(args.thread_size):
             job = executor.submit(fib, i)
             jobs.append(job)
 
@@ -98,7 +75,7 @@ def main():
     executor = ProcessPoolExecutor(max_workers=4)
     with executor:
         jobs = []
-        for i in range(size):
+        for i in range(args.process_size):
             job = executor.submit(fib, i)
             jobs.append(job)
 
@@ -112,10 +89,28 @@ def main():
             job.result()
 
 
+@profile
+def funcy_fib(n):
+    """
+    Alternatite fib function where code splits out over multiple lines
+    """
+    a, b = (
+        0, 1
+    )
+    while a < n:
+        # print(
+        #     a, end=' ')
+        a, b = b, \
+                a + b
+    # print(
+    # )
+
+
 if __name__ == '__main__':
     """
     CommandLine:
         cd ~/code/line_profiler/tests/
         python complex_example.py --size 10
+        python complex_example.py --serial_size 100000 --thread_size 0 --process_size 0
     """
     main()

--- a/tests/test_complex_case.py
+++ b/tests/test_complex_case.py
@@ -50,8 +50,9 @@ def test_complex_example():
 
     complex_fpath = test_dpath / 'complex_example.py'
 
-    proc = subprocess.run([sys.executable, complex_fpath], capture_output=True,
-                          universal_newlines=True)
+    from subprocess import PIPE
+    proc = subprocess.run([sys.executable, complex_fpath], stdout=PIPE,
+                          stderr=PIPE, universal_newlines=True)
     print(proc.stdout)
     print(proc.stderr)
     print(proc.returncode)

--- a/tests/test_complex_case.py
+++ b/tests/test_complex_case.py
@@ -1,0 +1,58 @@
+
+
+def profile_now(func):
+    """
+    Wrap a function to print profile information after it is called.
+
+    Args:
+        func (Callable): function to profile
+
+    Returns:
+        Callable: the wrapped function
+    """
+    import line_profiler
+    profile = line_profiler.LineProfiler()
+    new_func = profile(func)
+
+    def wraper(*args, **kwargs):
+        try:
+            return new_func(*args, **kwargs)
+        except Exception:
+            pass
+        finally:
+            profile.print_stats(stripzeros=True)
+
+    wraper.new_func = new_func
+    return wraper
+
+
+def func_to_profile():
+    list(range(100000))
+    tuple(range(100000))
+    set(range(100000))
+
+
+def test_profile_now():
+    func = func_to_profile
+    profile_now(func)()
+
+
+def test_complex_example():
+    import sys
+    import pathlib
+    import subprocess
+
+    try:
+        test_dpath = pathlib.Path(__file__).parent
+    except NameError:
+        # for development
+        test_dpath = pathlib.Path('~/code/line_profiler/tests').expanduser()
+
+    complex_fpath = test_dpath / 'complex_example.py'
+
+    proc = subprocess.run([sys.executable, complex_fpath], capture_output=True,
+                          universal_newlines=True)
+    print(proc.stdout)
+    print(proc.stderr)
+    print(proc.returncode)
+    proc.check_returncode()

--- a/tests/test_complex_case.py
+++ b/tests/test_complex_case.py
@@ -41,6 +41,7 @@ def test_complex_example():
     import sys
     import pathlib
     import subprocess
+    import os
 
     try:
         test_dpath = pathlib.Path(__file__).parent
@@ -51,7 +52,7 @@ def test_complex_example():
     complex_fpath = test_dpath / 'complex_example.py'
 
     from subprocess import PIPE
-    proc = subprocess.run([sys.executable, complex_fpath], stdout=PIPE,
+    proc = subprocess.run([sys.executable, os.fspath(complex_fpath)], stdout=PIPE,
                           stderr=PIPE, universal_newlines=True)
     print(proc.stdout)
     print(proc.stderr)

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -104,3 +104,40 @@ def test_classmethod_decorator():
     assert profile.enable_count == 0
     assert val == C.c('test')
     assert profile.enable_count == 0
+
+
+def test_show_func_column_formatting():
+    from line_profiler.line_profiler import show_func
+    import line_profiler
+    import io
+    # Use a function in this file as an example
+    func = line_profiler.line_profiler.show_text
+    start_lineno = func.__code__.co_firstlineno
+    func_lines = list(func.__code__.co_lines())
+    filename = func.__code__.co_filename
+    func_name = func.__name__
+
+    unit = 1.0
+    output_unit = 1.0
+    stripzeros = False
+
+    # Build fake timeings for each line in the example function
+    timings = [
+        (line_tup[2], idx * 1e13, idx * (2e10 ** (idx % 3)))
+        for idx, line_tup in enumerate(func_lines, start=1)
+    ]
+    stream = io.StringIO()
+    show_func(filename, start_lineno, func_name, timings, unit,
+              output_unit, stream, stripzeros)
+    text = stream.getvalue()
+    print(text)
+
+    timings = [
+        (line_tup[2], idx * 1e15, idx * 2e19)
+        for idx, line_tup in enumerate(func_lines, start=1)
+    ]
+    stream = io.StringIO()
+    show_func(filename, start_lineno, func_name, timings, unit,
+              output_unit, stream, stripzeros)
+    text = stream.getvalue()
+    print(text)

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -118,7 +118,7 @@ def test_show_func_column_formatting():
 
     def get_func_linenos(func):
         import sys
-        if sys.version_info[0:2] > (3, 6):
+        if sys.version_info[0:2] >= (3, 10):
             return sorted(set([t[2] for t in func.__code__.co_lines()]))
         else:
             import dis


### PR DESCRIPTION
Use scientific notation when columns get too long. This should prevent columns from becoming misaligned in the output stats.

Adds several new tests for this and other potential issues.