### PR TITLE
Rich output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,9 @@ Changes
 
 4.1.0
 ~~~~
-* FIX: `show_text` now increases column sizes or switches to scientific notation to maintain alignment
-* ENH: `show_text` now has new options: sort and summarize
+* FIX: ``show_text`` now increases column sizes or switches to scientific notation to maintain alignment
+* ENH: ``show_text`` now has new options: sort and summarize
+* ENH: Added new CLI arguments ``-srm`` to ``line_profiler`` to control sorting, rich printing, and summary printing.
 
 4.0.3
 ~~~~

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -143,7 +143,7 @@ class LineProfiler(CLineProfiler):
             pickle.dump(lstats, f, pickle.HIGHEST_PROTOCOL)
 
     def print_stats(self, stream=None, output_unit=None, stripzeros=False,
-                    summarize=False, sort=False, rich=0):
+                    summarize=False, sort=False, rich=False):
         """ Show the gathered statistics.
         """
         lstats = self.get_stats()
@@ -415,7 +415,7 @@ def show_func(filename, start_lineno, func_name, timings, unit,
 
 
 def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False,
-              summarize=False, sort=False, rich=0):
+              details=True, summarize=False, sort=False, rich=False):
     """ Show text for the given timings.
     """
     if stream is None:
@@ -426,27 +426,25 @@ def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False,
     else:
         stream.write('Timer unit: %g s\n\n' % unit)
 
-    stats_order = sorted(stats.items())
-
     if sort:
-        # Order by increasing duration
-        stats_order = sorted(stats_order, key=lambda kv: sum(t[2] for t in kv[1]))
+        # Order by ascending duration
+        stats_order = sorted(stats.items(), key=lambda kv: sum(t[2] for t in kv[1]))
+    else:
+        # Default ordering
+        stats_order = sorted(stats.items())
 
-    for (fn, lineno, name), timings in stats_order:
-        show_func(fn, lineno, name, stats[fn, lineno, name], unit,
-                  output_unit=output_unit, stream=stream,
-                  stripzeros=stripzeros, rich=rich)
+    if details:
+        # Show detailed per-line information for each function.
+        for (fn, lineno, name), timings in stats_order:
+            show_func(fn, lineno, name, stats[fn, lineno, name], unit,
+                      output_unit=output_unit, stream=stream,
+                      stripzeros=stripzeros, rich=rich)
 
     if summarize:
         # Summarize the total time for each function
-
-        summary_rows = []
         for (fn, lineno, name), timings in stats_order:
             total_time = sum(t[2] for t in timings) * unit
-            summary_rows.append((total_time, fn, lineno, name))
-
-        for total, fn, lineno, name in summary_rows:
-            line = '%6.2f seconds - %s:%s - %s\n' % (total, fn, lineno, name)
+            line = '%6.2f seconds - %s:%s - %s\n' % (total_time, fn, lineno, name)
             stream.write(line)
 
 

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -143,13 +143,13 @@ class LineProfiler(CLineProfiler):
             pickle.dump(lstats, f, pickle.HIGHEST_PROTOCOL)
 
     def print_stats(self, stream=None, output_unit=None, stripzeros=False,
-                    summarize=False, sort=False):
+                    summarize=False, sort=False, rich=0):
         """ Show the gathered statistics.
         """
         lstats = self.get_stats()
         show_text(lstats.timings, lstats.unit, output_unit=output_unit,
                   stream=stream, stripzeros=stripzeros,
-                  summarize=summarize, sort=sort)
+                  summarize=summarize, sort=sort, rich=rich)
 
     def run(self, cmd):
         """ Profile a single executable statment in the main namespace.
@@ -209,7 +209,7 @@ def is_ipython_kernel_cell(filename):
 
 
 def show_func(filename, start_lineno, func_name, timings, unit,
-              output_unit=None, stream=None, stripzeros=False):
+              output_unit=None, stream=None, stripzeros=False, rich=False):
     """
     Show results for a single function.
 
@@ -237,6 +237,9 @@ def show_func(filename, start_lineno, func_name, timings, unit,
         stripzeros (bool):
             if True, prints nothing if the function was not run
 
+        rich (bool):
+            if True, attempt to use rich highlighting.
+
     Example:
         >>> from line_profiler.line_profiler import show_func
         >>> import line_profiler
@@ -257,8 +260,9 @@ def show_func(filename, start_lineno, func_name, timings, unit,
         >>> output_unit = 1.0
         >>> stream = None
         >>> stripzeros = False
+        >>> rich = 1
         >>> show_func(filename, start_lineno, func_name, timings, unit,
-        >>>           output_unit, stream, stripzeros)
+        >>>           output_unit, stream, stripzeros, rich)
     """
     if stream is None:
         stream = sys.stdout
@@ -266,6 +270,16 @@ def show_func(filename, start_lineno, func_name, timings, unit,
     total_time = sum(t[2] for t in timings)
     if stripzeros and total_time == 0:
         return
+
+    if rich:
+        try:
+            from rich.syntax import Syntax
+            from rich.highlighter import ReprHighlighter
+            from rich.text import Text
+            from rich.columns import Columns
+            from rich.console import Console
+        except ImportError:
+            rich = 0
 
     if output_unit is None:
         output_unit = unit
@@ -338,8 +352,8 @@ def show_func(filename, start_lineno, func_name, timings, unit,
 
     # template = '%6s %9s %12s %8s %8s  %-s'
     col_order = ['line', 'hits', 'time', 'perhit', 'percent']
-    template = ' '.join(['%' + str(column_sizes[k]) + 's' for k in col_order])
-    template = template + '  %-s'
+    lhs_template = ' '.join(['%' + str(column_sizes[k]) + 's' for k in col_order])
+    template = lhs_template + '  %-s'
 
     linenos = range(start_lineno, start_lineno + len(sublines))
     empty = ('', '', '', '')
@@ -350,17 +364,44 @@ def show_func(filename, start_lineno, func_name, timings, unit,
     stream.write('\n')
     stream.write('=' * len(header))
     stream.write('\n')
-    for lineno, line in zip(linenos, sublines):
-        nhits, time, per_hit, percent = display.get(lineno, empty)
-        txt = template % (lineno, nhits, time, per_hit, percent,
-                          line.rstrip('\n').rstrip('\r'))
-        stream.write(txt)
+
+    if rich:
+        import io
+        lhs_lines = []
+        rhs_lines = []
+        for lineno, line in zip(linenos, sublines):
+            nhits, time, per_hit, percent = display.get(lineno, empty)
+            txt = lhs_template % (lineno, nhits, time, per_hit, percent)
+
+            rhs_lines.append(line.rstrip('\n').rstrip('\r'))
+            lhs_lines.append(txt)
+
+        rhs_text = '\n'.join(rhs_lines)
+        lhs_text = '\n'.join(lhs_lines)
+
+        rhs = Syntax(rhs_text, 'python', background_color='default')
+        lhs = Text(lhs_text)
+        ReprHighlighter().highlight(lhs)
+        renderable = Columns([lhs, '', rhs])
+        tmp = io.StringIO()
+        # write_console = Console(file=tmp, force_terminal=True, soft_wrap=True)
+        write_console = Console(file=tmp, soft_wrap=True, color_system='standard')
+        write_console.print(renderable)
+        block = tmp.getvalue()
+        stream.write(block)
         stream.write('\n')
+    else:
+        for lineno, line in zip(linenos, sublines):
+            nhits, time, per_hit, percent = display.get(lineno, empty)
+            txt = template % (lineno, nhits, time, per_hit, percent,
+                              line.rstrip('\n').rstrip('\r'))
+            stream.write(txt)
+            stream.write('\n')
     stream.write('\n')
 
 
 def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False,
-              summarize=False, sort=False):
+              summarize=False, sort=False, rich=0):
     """ Show text for the given timings.
     """
     if stream is None:
@@ -380,7 +421,7 @@ def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False,
     for (fn, lineno, name), timings in stats_order:
         show_func(fn, lineno, name, stats[fn, lineno, name], unit,
                   output_unit=output_unit, stream=stream,
-                  stripzeros=stripzeros)
+                  stripzeros=stripzeros, rich=rich)
 
     if summarize:
         # Summarize the total time for each function
@@ -391,7 +432,7 @@ def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False,
             summary_rows.append((total_time, fn, lineno, name))
 
         for total, fn, lineno, name in summary_rows:
-            line = '%6.2f seconds - %s:%s:%s\n' % (total, fn, lineno, name)
+            line = '%6.2f seconds - %s:%s - %s\n' % (total, fn, lineno, name)
             stream.write(line)
 
 
@@ -425,11 +466,35 @@ def main():
         action='store_true',
         help='Hide functions which have not been called',
     )
+    parser.add_argument(
+        '-r',
+        '--rich',
+        action='store_true',
+        help='Use rich formatting',
+    )
+    parser.add_argument(
+        '-s',
+        '--sort',
+        action='store_true',
+        help='Sort by ascending total time',
+    )
+    parser.add_argument(
+        '-m',
+        '--summarize',
+        action='store_true',
+        help='Print a summary of total function time',
+    )
     parser.add_argument('profile_output', help='*.lprof file created by kernprof')
 
     args = parser.parse_args()
     lstats = load_stats(args.profile_output)
-    show_text(lstats.timings, lstats.unit, output_unit=args.unit, stripzeros=args.skip_zero)
+    show_text(
+        lstats.timings, lstats.unit, output_unit=args.unit,
+        stripzeros=args.skip_zero,
+        rich=args.rich,
+        sort=args.sort,
+        summarize=args.summarize,
+    )
 
 
 if __name__ == '__main__':

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -143,13 +143,13 @@ class LineProfiler(CLineProfiler):
             pickle.dump(lstats, f, pickle.HIGHEST_PROTOCOL)
 
     def print_stats(self, stream=None, output_unit=None, stripzeros=False,
-                    summarize=False, sort=False, rich=False):
+                    details=True, summarize=False, sort=False, rich=False):
         """ Show the gathered statistics.
         """
         lstats = self.get_stats()
         show_text(lstats.timings, lstats.unit, output_unit=output_unit,
                   stream=stream, stripzeros=stripzeros,
-                  summarize=summarize, sort=sort, rich=rich)
+                  details=details, summarize=summarize, sort=sort, rich=rich)
 
     def run(self, cmd):
         """ Profile a single executable statment in the main namespace.

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,3 @@
 # Add requirements here, use the script for help 
-# xdev availpkg pygments
+# xdev availpkg rich
+rich>=12.3.0


### PR DESCRIPTION
Factored the rich output features out of https://github.com/pyutils/line_profiler/pull/222 into its own PR.

 Adds several options to `show_text` to control:
 
 * if the per-function output is sorted by ascending total time
 * if a summary of the per-function total time is shown at the end
 * if we attempt to use rich to highlight the CLI output.

These options can also be controlled from the CLI using new arguments:

```python
    parser.add_argument(
        '-r',
        '--rich',
        action='store_true',
        help='Use rich formatting',
    )
    parser.add_argument(
        '-t',
        '--sort',
        action='store_true',
        help='Sort by ascending total time',
    )
    parser.add_argument(
        '-m',
        '--summarize',
        action='store_true',
        help='Print a summary of total function time',
    )
```

The output is pretty:

![image](https://github.com/pyutils/line_profiler/assets/3186211/7bbca8dd-8f79-40f2-a6df-ee4ac229fe84)


This builds on an older PR: https://github.com/pyutils/line_profiler/pull/221 I ninja merged that adds the summary and sorting features to the `show_text` function (and also fixes column formatting issues), but this PR exposes them to the user. As such - because this hasn't been released, new code introduced in that PR is subject to discussion and change here. 

Looking for feedback on the UX here:

* Are these good names for the CLI flags?
* Should we support more sorting orders other than the default (which is based on function name - and IMO kinda weird) and ascending time?


Notes:

* Discussion on better way to do the rich implementation: https://github.com/Textualize/rich/discussions/3076