### PR TITLE
Dont require ipython for at cibuildwheel test time

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,4 @@
 # Add requirements here, use the script for help 
 # xdev availpkg rich
 rich>=12.3.0
+-r ipython.txt

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,6 +13,4 @@ pytest-cov>=2.8.1           ; python_version < '2.8.0'  and python_version >= '2
 coverage[toml] >= 5.3
 ubelt >= 1.3.3
 
--r ipython.txt
-
 xdoctest >= 1.1.1

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,10 +1,14 @@
 import unittest
 
-from IPython.testing.globalipapp import get_ipython
-
 
 class TestIPython(unittest.TestCase):
     def test_init(self):
+        try:
+            from IPython.testing.globalipapp import get_ipython
+        except ImportError:
+            import pytest
+            pytest.skip()
+
         ip = get_ipython()
         ip.run_line_magic('load_ext', 'line_profiler')
         ip.run_cell(raw_cell='def func():\n    return 2**20')


### PR DESCRIPTION
Should speedup the build part of the CI by only running the basic tests in cibuildwheel. The optional tests are handled later actions.