### PR TITLE
get_stats: Avoid dict conversion of c_code_map for each element of code_hash_map

### DIFF
--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -356,11 +356,10 @@ cdef class LineProfiler:
         """ 
         Return a LineStats object containing the timings.
         """
-        cdef dict cmap
+        cdef dict cmap = self._c_code_map
         
         stats = {}
         for code in self.code_hash_map:
-            cmap = self._c_code_map
             entries = []
             for entry in self.code_hash_map[code]:
                 entries += list(cmap[entry].values())


### PR DESCRIPTION
## Issue

For each call of `get_stats`, the implicit conversion of the C++ `unordered_mapping` `c_code_map` to a Python dict is currently being performed `len(code_hash_map)` -times. In scenarios where a large amount of code is being profiled, this can result in a significant performance penalty.

### The fix in this PR

Moving the implicit conversion out of the loop and only performing it once is what this PR proposes.

### In numbers

In our use case, line-profiler 4.x has been unusable due to this performance hit (which I've only just quantified and narrowed down to this conversion today):

With `len(code_hash_map)` at around 1000, line_profiler main branch shows for me:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    2.043    1.021    2.044    1.022 _line_profiler.pyx:358(get_stats)
```

And with this PR:
```
        2    0.010    0.005    0.010    0.005 _line_profiler.pyx:358(get_stats)
```

