### PR TITLE
Support 32bit system

### DIFF
--- a/line_profiler/timers.c
+++ b/line_profiler/timers.c
@@ -62,7 +62,7 @@ hpTimer(void)
         struct timespec ts;
         PY_LONG_LONG ret;
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        ret = (int64_t)ts.tv_sec * 1000000000 + (int64_t)ts.tv_nsec;
+        ret = (PY_LONG_LONG)ts.tv_sec * 1000000000 + (PY_LONG_LONG)ts.tv_nsec;
         return ret;
 }
 

--- a/line_profiler/timers.c
+++ b/line_profiler/timers.c
@@ -62,7 +62,7 @@ hpTimer(void)
         struct timespec ts;
         PY_LONG_LONG ret;
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        ret = ts.tv_sec * 1000000000 + ts.tv_nsec;
+        ret = (int64_t)ts.tv_sec * 1000000000 + (int64_t)ts.tv_nsec;
         return ret;
 }
 


### PR DESCRIPTION
So I had a problem running the `line_profiler` on a RPI - 32bit system.
Whenever I tried to profile a function that exceeds some time limit, the `line_profiler` report show negative values for time measuring variables.
I believe I have experienced this kind of behavior due to overflow.

Showcase:

`foo.py`:
        ![image](https://github.com/pyutils/line_profiler/assets/63425950/faf741d6-23f2-490a-bbe5-e77a725a5ccc)


Simulation of `foo.py` **before** the changes I represent in this PR:
        ![image](https://github.com/pyutils/line_profiler/assets/63425950/4501ba40-0b81-441a-8512-05f841551b17)


Simulation of `foo.py` **after** the changes I represent in this PR:
        ![image](https://github.com/pyutils/line_profiler/assets/63425950/b0e50763-46bf-42c0-a9ca-d6ff995c7392)