### PR TITLE
Respect stripzeros in summary report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changes
 
 4.1.3
 ~~~~~
+* FIX: duration summary now respects the stripzeros argument.
 
 4.1.2
 ~~~~~
@@ -15,7 +16,7 @@ Changes
 * FIX: ``get_stats`` is no longer slowed down when profiling many code sections #236
 
 4.1.0
-~~~~
+~~~~~
 * FIX: skipzeros now checks for zero hits instead of zero time
 * FIX: Fixed errors in Python 3.11 with duplicate functions.
 * FIX: ``show_text`` now increases column sizes or switches to scientific notation to maintain alignment

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -467,8 +467,9 @@ def show_text(stats, unit, output_unit=None, stream=None, stripzeros=False,
         # Summarize the total time for each function
         for (fn, lineno, name), timings in stats_order:
             total_time = sum(t[2] for t in timings) * unit
-            line = '%6.2f seconds - %s:%s - %s\n' % (total_time, fn, lineno, name)
-            stream.write(line)
+            if not stripzeros or total_time:
+                line = '%6.2f seconds - %s:%s - %s\n' % (total_time, fn, lineno, name)
+                stream.write(line)
 
 
 def load_stats(filename):

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -119,7 +119,8 @@ def test_show_func_column_formatting():
     def get_func_linenos(func):
         import sys
         if sys.version_info[0:2] >= (3, 10):
-            return sorted(set([t[2] for t in func.__code__.co_lines()]))
+            return sorted(set([t[0] if t[2] is None else t[2]
+                               for t in func.__code__.co_lines()]))
         else:
             import dis
             return sorted(set([t[1] for t in dis.findlinestarts(func.__code__)]))


### PR DESCRIPTION
In the latest version the "summarize" part of `line_profiler.line_profiler.show_text` will display the duration of all decorated functions even if stripzeros is True and the total time is zero. This PR patches that so now only the non-zero durations will print when this is true. 