### PR TITLE
Ensure x86 and arm64 wheels are built for osx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,7 @@ jobs:
         - ubuntu-latest
         - macOS-latest
         - windows-latest
+        - macos-13
         cibw_skip:
         - '*-win32'
         arch:
@@ -405,8 +406,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && ! startsWith(github.event.ref, 'refs/tags') && ! startsWith(github.event.ref, 'refs/heads/release')
     needs:
-    - build_binpy_wheels
     - build_and_test_sdist
+    - build_binpy_wheels
     steps:
     - name: Checkout source
       uses: actions/checkout@v4.1.1
@@ -479,8 +480,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || startsWith(github.event.ref, 'refs/heads/release'))
     needs:
-    - build_binpy_wheels
     - build_and_test_sdist
+    - build_binpy_wheels
     steps:
     - name: Checkout source
       uses: actions/checkout@v4.1.1


### PR DESCRIPTION
Have cibuildwheel run on macOS-latest and macos-13 for x86 and arm64 wheel variants.