### PR TITLE
Added support for annotated assignments in the static parser

### DIFF
--- a/line_profiler/autoprofile/util_static.py
+++ b/line_profiler/autoprofile/util_static.py
@@ -181,6 +181,10 @@ def _static_parse(varname, fpath):
                 if getattr(target, "id", None) == varname:
                     self.static_value = _parse_static_node_value(node.value)
 
+        def visit_AnnAssign(self, node):
+            if getattr(node.target, "id", None) == varname:
+                self.static_value = _parse_static_node_value(node.value)
+
     visitor = StaticVisitor()
     visitor.visit(pt)
     try:


### PR DESCRIPTION
(Closes issue #279)

Added support for annotated assignments in the static parser used by auto-profiling, so that type-annotated `__editable___*finder.py` scripts (as generated e.g. by `setuptools >= 70.0`) can be correctly handled