### PR TITLE
ENH: auto-profile module execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changes
 * ENH: Add support for ``sys.monitoring`` (Python >= 3.12)
 * FIX: Fixed issue when calling ``kernprof`` with neither the ``-l`` nor ``-b`` flag; also refactored common methods to ``LineProfiler`` and ``ContextualProfile``
 * FIX: Fixed auto-profiling of async function definitions #330
-* ENH: Added CLI argument ``-m`` to ``kernprof`` for (auto-)profiling module/package execution instead of that of scripts.
+* ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script```
 
 4.2.0
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changes
 * ENH: Add support for ``sys.monitoring`` (Python >= 3.12)
 * FIX: Fixed issue when calling ``kernprof`` with neither the ``-l`` nor ``-b`` flag; also refactored common methods to ``LineProfiler`` and ``ContextualProfile``
 * FIX: Fixed auto-profiling of async function definitions #330
-* ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script```
+* ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script; also made it possible for profiling targets to be supplied across multiple ``-p`` flags
 
 4.2.0
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changes
 * ENH: Add support for ``sys.monitoring`` (Python >= 3.12)
 * FIX: Fixed issue when calling ``kernprof`` with neither the ``-l`` nor ``-b`` flag; also refactored common methods to ``LineProfiler`` and ``ContextualProfile``
 * FIX: Fixed auto-profiling of async function definitions #330
+* ENH: Added CLI argument ``-m`` to ``kernprof`` for (auto-)profiling module/package execution instead of that of scripts.
 
 4.2.0
 ~~~~~

--- a/kernprof.py
+++ b/kernprof.py
@@ -342,7 +342,7 @@ def main(args=None):
                                 ns,
                                 prof_mod=prof_mod,
                                 profile_imports=options.prof_imports,
-                                as_module=options.script if options.module else None)
+                                as_module=options.module)
             elif options.module and options.builtin:
                 run_module(options.script, ns, '__main__')
             elif options.builtin:

--- a/kernprof.py
+++ b/kernprof.py
@@ -280,6 +280,12 @@ def main(args=None):
         options.outfile = '%s.%s' % (os.path.basename(options.script), extension)
 
     sys.argv = [options.script] + options.args
+    if options.module:
+        # Make sure the current directory is on `sys.path` to emulate
+        # `python -m`
+        # Note: this NEEDS to happen here, before the setup script (or
+        # any other code) has a chance to `os.chdir()`
+        sys.path.insert(0, os.path.abspath(os.curdir))
     if options.setup is not None:
         # Run some setup code outside of the profiler. This is good for large
         # imports.
@@ -317,11 +323,11 @@ def main(args=None):
         script_file = find_module_script(options.script)
     else:
         script_file = find_script(options.script)
+        # Make sure the script's directory is on sys.path instead of
+        # just kernprof.py's.
+        sys.path.insert(0, os.path.dirname(script_file))
     __file__ = script_file
     __name__ = '__main__'
-    # Make sure the script's directory is on sys.path instead of just
-    # kernprof.py's.
-    sys.path.insert(0, os.path.dirname(script_file))
 
     if options.output_interval:
         rt = RepeatedTimer(max(options.output_interval, 1), prof.dump_stats, options.outfile)

--- a/kernprof.py
+++ b/kernprof.py
@@ -315,8 +315,6 @@ def main(args=None):
 
     if options.module:
         script_file = find_module_script(options.script)
-        if options.prof_mod is None:
-            options.prof_mod = options.script
     else:
         script_file = find_script(options.script)
     __file__ = script_file

--- a/kernprof.py
+++ b/kernprof.py
@@ -45,7 +45,7 @@ To view kernprof help run:
 
 .. code:: bash
 
-    kenprof --help
+    kernprof --help
 
 which displays:
 
@@ -177,11 +177,11 @@ class RepeatedTimer:
 
 
 def find_module_script(module_name):
-    """Find the path to the executable script for a module."""
+    """Find the path to the executable script for a module or package."""
     from line_profiler.autoprofile.util_static import modname_to_modpath
 
-    for suiifx in '.__main__', '':
-        fname = modname_to_modpath(module_name + suiifx)
+    for suffix in '.__main__', '':
+        fname = modname_to_modpath(module_name + suffix)
         if fname:
             return fname
 

--- a/line_profiler/autoprofile/ast_profile_transformer.py
+++ b/line_profiler/autoprofile/ast_profile_transformer.py
@@ -14,13 +14,14 @@ def ast_create_profile_node(modname, profiler_name='profile', attr='add_imported
         >>> profile.add_imported_function_or_module(foo.bar)
 
     Args:
-        script_file (str):
-            path to script being profiled.
+        modname (str):
+            name of the imported module.
 
-        prof_mod (List[str]):
-            list of imports to profile in script.
-            passing the path to script will profile the whole script.
-            the objects can be specified using its dotted path or full path (if applicable).
+        profiler_name (str):
+            name of the LineProfiler object.
+
+        attr (str):
+            name of the method of the LineProfiler object to call on the imported module.
 
     Returns:
         (_ast.Expr): expr

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -47,6 +47,7 @@ profiles it with autoprofile.
 
 import types
 from .ast_tree_profiler import AstTreeProfiler
+from .run_module import AstTreeModuleProfiler
 from .line_profiler_utils import add_imported_function_or_module
 
 PROFILER_LOCALS_NAME = 'prof'
@@ -67,7 +68,7 @@ def _extend_line_profiler_for_profiling_imports(prof):
     prof.add_imported_function_or_module = types.MethodType(add_imported_function_or_module, prof)
 
 
-def run(script_file, ns, prof_mod, profile_imports=False):
+def run(script_file, ns, prof_mod, profile_imports=False, as_module=None):
     """Automatically profile a script and run it.
 
     Profile functions, classes & modules specified in prof_mod without needing to add
@@ -87,8 +88,18 @@ def run(script_file, ns, prof_mod, profile_imports=False):
 
         profile_imports (bool):
             if True, when auto-profiling whole script, profile all imports aswell.
+
+        as_module (str | None):
+            The module full (dotted) path if script_file is to be run as a module
     """
-    tree_profiled = AstTreeProfiler(script_file, prof_mod, profile_imports).profile()
+    if as_module:
+        profiler = AstTreeModuleProfiler(script_file,
+                                         as_module,
+                                         prof_mod,
+                                         profile_imports)
+    else:
+        profiler = AstTreeProfiler(script_file, prof_mod, profile_imports)
+    tree_profiled = profiler.profile()
 
     _extend_line_profiler_for_profiling_imports(ns[PROFILER_LOCALS_NAME])
     code_obj = compile(tree_profiled, script_file, 'exec')

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -68,7 +68,7 @@ def _extend_line_profiler_for_profiling_imports(prof):
     prof.add_imported_function_or_module = types.MethodType(add_imported_function_or_module, prof)
 
 
-def run(script_file, ns, prof_mod, profile_imports=False, as_module=None):
+def run(script_file, ns, prof_mod, profile_imports=False, as_module=False):
     """Automatically profile a script and run it.
 
     Profile functions, classes & modules specified in prof_mod without needing to add
@@ -89,16 +89,11 @@ def run(script_file, ns, prof_mod, profile_imports=False, as_module=None):
         profile_imports (bool):
             if True, when auto-profiling whole script, profile all imports aswell.
 
-        as_module (str | None):
-            The module full (dotted) path if script_file is to be run as a module
+        as_module (bool):
+            Whether we're running script_file as a module
     """
-    if as_module:
-        profiler = AstTreeModuleProfiler(script_file,
-                                         as_module,
-                                         prof_mod,
-                                         profile_imports)
-    else:
-        profiler = AstTreeProfiler(script_file, prof_mod, profile_imports)
+    Profiler = AstTreeModuleProfiler if as_module else AstTreeProfiler
+    profiler = Profiler(script_file, prof_mod, profile_imports)
     tree_profiled = profiler.profile()
 
     _extend_line_profiler_for_profiling_imports(ns[PROFILER_LOCALS_NAME])

--- a/line_profiler/autoprofile/autoprofile.pyi
+++ b/line_profiler/autoprofile/autoprofile.pyi
@@ -6,5 +6,6 @@ PROFILER_LOCALS_NAME: str
 def run(script_file: str,
         ns: dict,
         prof_mod: List[str],
-        profile_imports: bool = False) -> None:
+        profile_imports: bool = False,
+        as_module: str | None = None) -> None:
     ...

--- a/line_profiler/autoprofile/autoprofile.pyi
+++ b/line_profiler/autoprofile/autoprofile.pyi
@@ -7,5 +7,5 @@ def run(script_file: str,
         ns: dict,
         prof_mod: List[str],
         profile_imports: bool = False,
-        as_module: str | None = None) -> None:
+        as_module: bool = False) -> None:
     ...

--- a/line_profiler/autoprofile/run_module.py
+++ b/line_profiler/autoprofile/run_module.py
@@ -1,0 +1,111 @@
+import ast
+import os
+
+from .ast_tree_profiler import AstTreeProfiler
+from .util_static import modname_to_modpath
+
+
+def get_module_from_importfrom(node, module):
+    r"""Resolve the full path of a relative import.
+
+    Args:
+        node (ast.ImportFrom)
+            ImportFrom node
+        module (str)
+            Full path relative to which the import is to occur
+
+    Return:
+        modname (str)
+            Full path of the module from which the names are to be
+            imported
+
+    Example:
+        >>> import ast
+        >>> import functools
+        >>> import textwrap
+        >>>
+        >>>
+        >>> abs_import, *rel_imports = ast.parse(textwrap.dedent('''
+        ... from a import b
+        ... from . import b
+        ... from .. import b
+        ... from .baz import b
+        ... from ..baz import b
+        ... '''.strip('\n'))).body
+        >>>
+        >>>
+        >>> get_module = functools.partial(get_module_from_importfrom,
+        ...                                module='foo.bar')
+        >>> assert get_module(abs_import) == 'a'
+        >>> assert get_module(rel_imports[0]) == 'foo.bar'
+        >>> assert get_module(rel_imports[1]) == 'foo'
+        >>> assert get_module(rel_imports[2]) == 'foo.bar.baz'
+        >>> assert get_module(rel_imports[3]) == 'foo.baz'
+    """
+    level = node.level
+    if not level:
+        return node.module
+    if level > 1:
+        module = '.'.join(module.split('.')[:-(level - 1)])
+    if node.module:
+        return module + '.' + node.module
+    return module
+
+
+class ImportFromTransformer(ast.NodeTransformer):
+    """Turn all the relative imports into absolute imports."""
+    def __init__(self, module):
+        self.module = module
+
+    def visit_ImportFrom(self, node):
+        level = node.level
+        if not level:
+            return self.generic_visit(node)
+        module = get_module_from_importfrom(node, self.module)
+        new_node = ast.ImportFrom(module=module,
+                                  names=node.names,
+                                  level=0)
+        return self.generic_visit(ast.copy_location(new_node, node))
+
+
+class AstTreeModuleProfiler(AstTreeProfiler):
+    """Create an abstract syntax tree of an executable module and add
+    profiling to it.
+
+    Reads the module code and generates an abstract syntax tree, then adds nodes
+    and/or decorators to the AST that adds the specified functions/methods,
+    classes & modules in prof_mod to the profiler to be profiled.
+    """
+    def __init__(self, module_file, module_name, *args, **kwargs):
+        """Initializes the AST tree profiler instance with the executable module
+        file and module name.
+
+        Args:
+            module_file (str):
+                the module file or its `__main__.py` if a package.
+
+            module_name (str):
+                name of the module being profiled.
+
+            *args, **kwargs:
+                passed to `.ast_tree_profiler.AstTreeProfiler`.
+        """
+        self._module = module_name
+        super().__init__(module_file, *args, **kwargs)
+
+    def _get_script_ast_tree(self, script_file):
+        tree = super()._get_script_ast_tree(script_file)
+        return ImportFromTransformer(self._module).visit(tree)
+
+    @staticmethod
+    def _check_profile_full_script(script_file, prof_mod):
+        rp = os.path.realpath
+        paths_to_check = {rp(script_file)}
+        if os.path.basename(script_file) == '__main__.py':
+            paths_to_check.add(rp(os.path.dirname(script_file)))
+        paths_to_profile = {rp(mod) for mod in prof_mod}
+        for mod in prof_mod:
+            as_path = modname_to_modpath(mod)
+            if as_path:
+                paths_to_profile.add(rp(as_path))
+        return bool(paths_to_check & paths_to_profile)

--- a/line_profiler/autoprofile/run_module.pyi
+++ b/line_profiler/autoprofile/run_module.pyi
@@ -1,0 +1,24 @@
+import _ast
+
+from .ast_tree_profiler import AstTreeProfiler
+
+
+def get_module_from_importfrom(node: _ast.ImportFrom, module: str) -> str:
+    ...
+
+
+class ImportFromTransformer(_ast.NodeTransformer):
+    def __init__(self, module: str) -> None:
+        ...
+
+    def visit_ImportFrom(self, _ast.ImportFrom) -> _ast.ImportFrom:
+        ...
+
+    module: str
+
+
+class AstTreeModuleProfiler(AstTreeProfiler):
+    def __init__(self, module_file: str, module_name: str, *args, **kwargs):
+        ...
+
+    _module: str

--- a/line_profiler/autoprofile/run_module.pyi
+++ b/line_profiler/autoprofile/run_module.pyi
@@ -1,17 +1,17 @@
-import _ast
+import ast
 
 from .ast_tree_profiler import AstTreeProfiler
 
 
-def get_module_from_importfrom(node: _ast.ImportFrom, module: str) -> str:
+def get_module_from_importfrom(node: ast.ImportFrom, module: str) -> str:
     ...
 
 
-class ImportFromTransformer(_ast.NodeTransformer):
+class ImportFromTransformer(ast.NodeTransformer):
     def __init__(self, module: str, main: bool = False) -> None:
         ...
 
-    def visit_ImportFrom(self, _ast.ImportFrom) -> _ast.ImportFrom:
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.ImportFrom:
         ...
 
     module: str

--- a/line_profiler/autoprofile/run_module.pyi
+++ b/line_profiler/autoprofile/run_module.pyi
@@ -8,13 +8,14 @@ def get_module_from_importfrom(node: _ast.ImportFrom, module: str) -> str:
 
 
 class ImportFromTransformer(_ast.NodeTransformer):
-    def __init__(self, module: str) -> None:
+    def __init__(self, module: str, main: bool = False) -> None:
         ...
 
     def visit_ImportFrom(self, _ast.ImportFrom) -> _ast.ImportFrom:
         ...
 
     module: str
+    main: bool
 
 
 class AstTreeModuleProfiler(AstTreeProfiler):
@@ -22,3 +23,4 @@ class AstTreeModuleProfiler(AstTreeProfiler):
         ...
 
     _module: str
+    _main: bool

--- a/line_profiler/autoprofile/run_module.pyi
+++ b/line_profiler/autoprofile/run_module.pyi
@@ -8,19 +8,14 @@ def get_module_from_importfrom(node: ast.ImportFrom, module: str) -> str:
 
 
 class ImportFromTransformer(ast.NodeTransformer):
-    def __init__(self, module: str, main: bool = False) -> None:
+    def __init__(self, module: str) -> None:
         ...
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.ImportFrom:
         ...
 
     module: str
-    main: bool
 
 
 class AstTreeModuleProfiler(AstTreeProfiler):
-    def __init__(self, module_file: str, module_name: str, *args, **kwargs):
-        ...
-
-    _module: str
-    _main: bool
+    ...

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -435,6 +435,10 @@ def test_autoprofile_script_with_prof_imports():
     [(False, 'test_mod.submod1', False, True, False, False, False),
      (False, 'test_mod.submod2', True, False, True, True, False),
      (False, 'test_mod', True, True, True, True, True),
+     # Explicitly add all the modules via multiple `-p` flags, without
+     # using the `--prof-imports` flag
+     (False, ['test_mod', 'test_mod.submod1,test_mod.submod2'], False,
+      True, True, True, True),
      (False, None, True, False, False, False, False),
      (True, None, True, False, False, False, False)])
 def test_autoprofile_exec_package(
@@ -451,7 +455,10 @@ def test_autoprofile_exec_package(
     else:
         args = [sys.executable, '-m', 'kernprof']
     if prof_mod is not None:
-        args.extend(['-p', prof_mod])
+        if isinstance(prof_mod, str):
+            prof_mod = [prof_mod]
+        for pm in prof_mod:
+            args.extend(['-p', pm])
     if prof_imports:
         args.append('--prof-imports')
     args.extend(['-l', '-m', 'test_mod', '1', '2', '3'])

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -433,8 +433,8 @@ def test_autoprofile_script_with_prof_imports():
     ['prof_mod', 'prof_imports', 'add_one', 'add_two', 'add_operator', 'main'],
     [('test_mod.submod1', False, True, False, False, False),
      ('test_mod.submod2', True, False, True, True, False),
-     # `prof_mod = None` -> `-p test_mod`
-     (None, True, True, True, True, True)])
+     ('test_mod', True, True, True, True, True),
+     (None, True, False, False, False, False)])
 def test_autoprofile_exec_package(
         prof_mod, prof_imports, add_one, add_two, add_operator, main):
     """
@@ -474,8 +474,7 @@ def test_autoprofile_exec_package(
     [('test_mod.submod2', False, False, True, False, False, False),
      ('test_mod.submod1', False, True, False, False, True, False),
      ('test_mod.subpkg.submod4', True, True, True, True, True, True),
-     # `prof_mod = None` -> `-p test_mod.subpkg.submod4`
-     (None, True, True, True, True, True, True)])
+     (None, True, False, False, False, False, False)])
 def test_autoprofile_exec_module(
         prof_mod, prof_imports, add_one, add_two, add_four, add_operator, main):
     """

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -430,20 +430,26 @@ def test_autoprofile_script_with_prof_imports():
 
 
 @pytest.mark.parametrize(
-    ['prof_mod', 'prof_imports', 'add_one', 'add_two', 'add_operator', 'main'],
-    [('test_mod.submod1', False, True, False, False, False),
-     ('test_mod.submod2', True, False, True, True, False),
-     ('test_mod', True, True, True, True, True),
-     (None, True, False, False, False, False)])
+    ['use_kernprof_exec', 'prof_mod', 'prof_imports',
+     'add_one', 'add_two', 'add_operator', 'main'],
+    [(False, 'test_mod.submod1', False, True, False, False, False),
+     (False, 'test_mod.submod2', True, False, True, True, False),
+     (False, 'test_mod', True, True, True, True, True),
+     (False, None, True, False, False, False, False),
+     (True, None, True, False, False, False, False)])
 def test_autoprofile_exec_package(
-        prof_mod, prof_imports, add_one, add_two, add_operator, main):
+        use_kernprof_exec, prof_mod, prof_imports,
+        add_one, add_two, add_operator, main):
     """
     Test the execution of a package.
     """
     temp_dpath = ub.Path(tempfile.mkdtemp())
     _write_demo_module(temp_dpath)
 
-    args = [sys.executable, '-m', 'kernprof']
+    if use_kernprof_exec:
+        args = ['kernprof']
+    else:
+        args = [sys.executable, '-m', 'kernprof']
     if prof_mod is not None:
         args.extend(['-p', prof_mod])
     if prof_imports:
@@ -469,21 +475,26 @@ def test_autoprofile_exec_package(
 
 
 @pytest.mark.parametrize(
-    ['prof_mod', 'prof_imports', 'add_one', 'add_two', 'add_four',
-     'add_operator', 'main'],
-    [('test_mod.submod2', False, False, True, False, False, False),
-     ('test_mod.submod1', False, True, False, False, True, False),
-     ('test_mod.subpkg.submod4', True, True, True, True, True, True),
-     (None, True, False, False, False, False, False)])
+    ['use_kernprof_exec', 'prof_mod', 'prof_imports',
+     'add_one', 'add_two', 'add_four', 'add_operator', 'main'],
+    [(False, 'test_mod.submod2', False, False, True, False, False, False),
+     (False, 'test_mod.submod1', False, True, False, False, True, False),
+     (False, 'test_mod.subpkg.submod4', True, True, True, True, True, True),
+     (False, None, True, False, False, False, False, False),
+     (True, None, True, False, False, False, False, False)])
 def test_autoprofile_exec_module(
-        prof_mod, prof_imports, add_one, add_two, add_four, add_operator, main):
+        use_kernprof_exec, prof_mod, prof_imports,
+        add_one, add_two, add_four, add_operator, main):
     """
     Test the execution of a module.
     """
     temp_dpath = ub.Path(tempfile.mkdtemp())
     _write_demo_module(temp_dpath)
 
-    args = [sys.executable, '-m', 'kernprof']
+    if use_kernprof_exec:
+        args = ['kernprof']
+    else:
+        args = [sys.executable, '-m', 'kernprof']
     if prof_mod is not None:
         args.extend(['-p', prof_mod])
     if prof_imports:

--- a/tests/test_explicit_profile.py
+++ b/tests/test_explicit_profile.py
@@ -1,6 +1,7 @@
-import tempfile
-import sys
 import os
+import re
+import sys
+import tempfile
 
 import pytest
 import ubelt as ub
@@ -167,6 +168,101 @@ def test_explicit_profile_with_kernprof(line_profile: bool):
     temp_dpath.delete()
 
 
+@pytest.mark.parametrize('package', [True, False])
+@pytest.mark.parametrize('builtin', [True, False])
+def test_explicit_profile_with_kernprof_m(builtin: bool, package: bool):
+    """
+    Test that explicit (non-line) profiling works when using
+    `kernprof -m` to run packages and/or submodules with relative
+    imports.
+
+    Parameters:
+        builtin (bool)
+            Whether to slip `@profile` into the globals with `--builtin`
+            (true) or to require importing it from `line_profiler` in
+            the profiled source code (false)
+
+        package (bool)
+            Whether to add the code to a package's `__main__.py` and
+            `kernprof -m {<package>}` (true), or to add it to a
+            submodule and `kernprof -m {<package>}.{<submodule>}`
+            (false)
+    """
+    temp_dpath = ub.Path(tempfile.mkdtemp())
+
+    lib_code = ub.codeblock(
+        '''
+        @profile
+        def func1(a):
+            return a + 1
+
+        @profile
+        def func2(a):
+            return a + 1
+
+        def func3(a):
+            return a + 1
+
+        def func4(a):
+            return a + 1
+        ''').strip()
+    if not builtin:
+        lib_code = 'from line_profiler import profile\n' + lib_code
+    target_code = ub.codeblock(
+        '''
+        from ._lib import func1, func2, func3, func4
+
+        if __name__ == '__main__':
+            func1(1)
+            func2(1)
+            func3(1)
+            func4(1)
+        ''').strip()
+
+    if package:
+        target_module = 'package'
+        target_fname = '__main__.py'
+    else:
+        target_module = 'package.api'
+        target_fname = 'api.py'
+
+    args = ['kernprof', '-m', '-v', target_module]
+    if builtin:
+        args.insert(-1, '--builtin')
+
+    if 'PYTHONPATH' in os.environ:
+        python_path = '{}:{}'.format(os.environ['PYTHONPATH'], os.curdir)
+    else:
+        python_path = os.curdir
+    env = {**os.environ, 'PYTHONPATH': python_path}
+
+    with ub.ChDir(temp_dpath):
+        package_dir = ub.Path('package').mkdir()
+
+        lib_fpath = package_dir / '_lib.py'
+        lib_fpath.write_text(lib_code)
+
+        target_fpath = package_dir / target_fname
+        target_fpath.write_text(target_code)
+
+        (package_dir / '__init__.py').touch()
+
+        proc = ub.cmd(args, env=env)
+        print(proc.stdout)
+        print(proc.stderr)
+        proc.check_returncode()
+
+    # Note: in non-builtin mode, the entire script is profiled
+    for func, profiled in [('func1', True), ('func2', True),
+                           ('func3', not builtin), ('func4', not builtin)]:
+        result = re.search(r'lib\.py:[0-9]+\({}\)'.format(func), proc.stdout)
+        assert bool(result) == profiled
+
+    assert not (temp_dpath / 'profile_output.txt').exists()
+    assert (temp_dpath / (target_module + '.prof')).exists()
+    temp_dpath.delete()
+
+
 def test_explicit_profile_with_in_code_enable():
     """
     Test that the user can enable the profiler explicitly from within their
@@ -309,6 +405,7 @@ def test_explicit_profile_with_duplicate_functions():
     assert output_fpath.exists()
     assert (temp_dpath / 'profile_output.lprof').exists()
     temp_dpath.delete()
+
 
 if __name__ == '__main__':
     ...

--- a/tests/test_explicit_profile.py
+++ b/tests/test_explicit_profile.py
@@ -226,9 +226,9 @@ def test_explicit_profile_with_kernprof_m(builtin: bool, package: bool):
         target_module = 'package.api'
         target_fname = 'api.py'
 
-    args = ['kernprof', '-m', '-v', target_module]
+    args = ['kernprof', '-v', '-m', target_module]
     if builtin:
-        args.insert(-1, '--builtin')
+        args.insert(2, '--builtin')  # Insert before the `-m` flag
 
     if 'PYTHONPATH' in os.environ:
         python_path = '{}:{}'.format(os.environ['PYTHONPATH'], os.curdir)


### PR DESCRIPTION
## Motivation

In issue #29, it was requested that support for running modules be added to `kernprof` via an `-m` flag. While it was noted that [*explicit* decoration with the `LINE_PROFILE=1` environment-variable switch](https://github.com/pyutils/line_profiler/issues/29#issuecomment-1692639599) can mitigate having to call `kernprof` off the command line, this does not cover the use-case of *auto-profiling* module execution, like how the existing invocation `kernprof -l -p... script.py` covers script execution.

## Code changes

This PR adds the requested (but see Caveats) functionality by:
- Adding the `-m`/~~`--module`~~ **EDIT 13 Apr: long-option form no longer supported** boolean flag to `kernprof.py::main()`
  - ~~Convenience: when `-m` is passed without specifying `-p`/`--prof-mod`, it defaults to `-p {<the_specified_module>}`~~ **EDIT 12 Apr: this is no longer the case, users should supply `-p<module>` explicitly**
  - **(EDIT 13 Apr)** Syntactics for `kernprof -m` updated to behave more like `python -m`; `kernprof -m` now:
    - Complains if there isn't a trailing argument (the module name) which isn't `--`
    - Terminates parsing for the arguments after the module name, passing them to the module as positional args
- Adding `kernprof.py::find_module_script()`, which leverages `line_profiler/autoprofile/util_static.py::modname_to_modpath()` to convert module/package dotted paths to their corresponding file paths; packages are detected and referred to the appropriate `__main__.py`
- Adding a `line_profiler/autoprofile/run_module.py::AstTreeModuleProfiler`, which rewrites relative imports into absolute imports, so that the resultant ASTs can be `compile()`-ed and subsequently `exec()`-ed as-is.
- Adding the parametrized tests `tests/test_autoprofile.py:: test_autoprofile_exec_{package,module}()` for the new functionality (`kernprof -l ... -m {<some_package_with_a_main_py>}` and `kernprof -l ... -m {<some_module>}`)
- **(EDIT 17 Mar)** Adding the parametrized test `tests/test_explicit_profile.py::test_explicit_profile_with_kernprof_m()` for the corresponding cases without the `-l`/`--line-by-line` flag
- **(EDIT 12 Apr)** Made `kernprof.py::main()` clean up after itself by restoring `sys.path` and `sys.argv` after its execution, as well as undoing the `line_profiler.profile._kernprof_overwrite()` with the `LineProfiler` instance created inside `main()`
- **(EDIT 13 Apr)** Adding the parametrized test `tests/test_kernprof.py::test_kernprof_m_parsing()` to test the special-casing of the `-m` flag (which must follow all other `kernprof` options and and be followed by a module name)

## Caveats

While this PR *technically* covers #29's use-case, in that `kernprof -l -m pytest {<tests>}` does profile whatever is already decorated with `@profile` in the tests, we still aren't auto-profiling tests, since it is the `pytest` module that would have been auto-profiled. Actually implementing auto-profiling for `pytest` tests (which [`pytest-line-profiler`](https://pypi.org/project/pytest-line-profiler/) does not handle, owing to how auto-profiling did not exist when the package was last updated) may be nontrivial, due to how `pytest` also does its own AST rewrites.