### PR TITLE
FIX: `kernprof` erroring out in non-`-l`, non-`-b` mode in Python 3.12+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changes
 ~~~~~
 * FIX: win32 encoding issues
 * ENH: Add support for ``sys.monitoring`` (Python >= 3.12)
+* FIX: Fixed issue when calling ``kernprof`` with neither the ``-l`` nor ``-b`` flag; also refactored common methods to ``LineProfiler`` and ``ContextualProfile``
 
 4.2.0
 ~~~~~

--- a/kernprof.py
+++ b/kernprof.py
@@ -114,8 +114,11 @@ class ContextualProfile(ByCountProfilerMixin, Profile):
     2.5 with: statements and a decorator.
     """
     def __init__(self, *args, **kwds):
-        super(ByCountProfilerMixin, self).__init__(*args, **kwds)
+        Profile.__init__(self, *args, **kwds)
         self.enable_count = 0
+
+    def __call__(self, func):
+        return self.wrap_callable(func)
 
     def enable_by_count(self, subcalls=True, builtins=True):
         """ Enable the profiler if it hasn't been enabled before.
@@ -136,11 +139,6 @@ class ContextualProfile(ByCountProfilerMixin, Profile):
     # FIXME: `profile.Profile` is fundamentally incompatible with the
     # by-count paradigm we use, as it can't be `.enable()`-ed nor
     # `.disable()`-ed
-    if Profile.__module__ == 'profile':
-        def __init__(self, *args, **kwds):  # noqa: F811
-            raise AssertionError('non-line-by-line profiling depends on '
-                                 'cProfile, which is not available on this '
-                                 'platform')
 
 
 class RepeatedTimer:
@@ -279,6 +277,9 @@ def main(args=None):
         import line_profiler
         prof = line_profiler.LineProfiler()
         options.builtin = True
+    elif Profile.__module__ == 'profile':
+        raise RuntimeError('non-line-by-line profiling depends on cProfile, '
+                           'which is not available on this platform')
     else:
         prof = ContextualProfile()
 

--- a/kernprof.py
+++ b/kernprof.py
@@ -114,7 +114,7 @@ class ContextualProfile(ByCountProfilerMixin, Profile):
     2.5 with: statements and a decorator.
     """
     def __init__(self, *args, **kwds):
-        Profile.__init__(self, *args, **kwds)
+        super(ByCountProfilerMixin, self).__init__(*args, **kwds)
         self.enable_count = 0
 
     def __call__(self, func):

--- a/kernprof.py
+++ b/kernprof.py
@@ -80,7 +80,6 @@ which displays:
       --prof-imports        If specified, modules specified to `--prof-mod` will also autoprofile modules that they import. Only works with line_profiler -l, --line-by-line
 """
 import builtins
-import functools
 import os
 import sys
 import threading
@@ -98,10 +97,9 @@ __version__ = '4.3.0'
 try:
     from cProfile import Profile
 except ImportError:
-    try:
-        from lsprof import Profile  # type: ignore[assignment,no-redef]
-    except ImportError:
-        from profile import Profile  # type: ignore[assignment,no-redef]
+    from profile import Profile  # type: ignore[assignment,no-redef]
+
+from line_profiler.profiler_mixin import ByCountProfilerMixin
 
 
 def execfile(filename, globals=None, locals=None):
@@ -111,43 +109,20 @@ def execfile(filename, globals=None, locals=None):
 # =====================================
 
 
-CO_GENERATOR = 0x0020
-
-
-def is_generator(f):
-    """ Return True if a function is a generator.
-    """
-    isgen = (f.__code__.co_flags & CO_GENERATOR) != 0
-    return isgen
-
-
-class ContextualProfile(Profile):
+class ContextualProfile(ByCountProfilerMixin, Profile):
     """ A subclass of Profile that adds a context manager for Python
     2.5 with: statements and a decorator.
     """
-
     def __init__(self, *args, **kwds):
-        super().__init__(*args, **kwds)
+        super(ByCountProfilerMixin, self).__init__(*args, **kwds)
         self.enable_count = 0
 
     def enable_by_count(self, subcalls=True, builtins=True):
         """ Enable the profiler if it hasn't been enabled before.
         """
         if self.enable_count == 0:
-            self.ensure_tool_id_availability()
             self.enable(subcalls=subcalls, builtins=builtins)
         self.enable_count += 1
-
-    @staticmethod
-    def ensure_tool_id_availability():
-        try:
-            profiler_id = sys.monitoring.PROFILER_ID
-        except AttributeError:  # Python < 3.12
-            return
-        tool_id = sys.monitoring.get_tool(profiler_id)
-        if tool_id is not None:
-            assert tool_id == 'cProfile'
-            sys.monitoring.free_tool_id(profiler_id)
 
     def disable_by_count(self):
         """ Disable the profiler if the number of disable requests matches the
@@ -158,65 +133,14 @@ class ContextualProfile(Profile):
             if self.enable_count == 0:
                 self.disable()
 
-    def __call__(self, func):
-        """ Decorate a function to start the profiler on function entry and stop
-        it on function exit.
-        """
-        # FIXME: refactor this into a utility function so that both it and
-        # line_profiler can use it.
-        if is_generator(func):
-            wrapper = self.wrap_generator(func)
-        else:
-            wrapper = self.wrap_function(func)
-        return wrapper
-
-    # FIXME: refactor this stuff so that both LineProfiler and
-    # ContextualProfile can use the same implementation.
-    def wrap_generator(self, func):
-        """ Wrap a generator to profile it.
-        """
-        @functools.wraps(func)
-        def wrapper(*args, **kwds):
-            g = func(*args, **kwds)
-            # The first iterate will not be a .send()
-            self.enable_by_count()
-            try:
-                item = next(g)
-            except StopIteration:
-                return
-            finally:
-                self.disable_by_count()
-            input = (yield item)
-            # But any following one might be.
-            while True:
-                self.enable_by_count()
-                try:
-                    item = g.send(input)
-                except StopIteration:
-                    return
-                finally:
-                    self.disable_by_count()
-                input = (yield item)
-        return wrapper
-
-    def wrap_function(self, func):
-        """ Wrap a function to profile it.
-        """
-        @functools.wraps(func)
-        def wrapper(*args, **kwds):
-            self.enable_by_count()
-            try:
-                result = func(*args, **kwds)
-            finally:
-                self.disable_by_count()
-            return result
-        return wrapper
-
-    def __enter__(self):
-        self.enable_by_count()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.disable_by_count()
+    # FIXME: `profile.Profile` is fundamentally incompatible with the
+    # by-count paradigm we use, as it can't be `.enable()`-ed nor
+    # `.disable()`-ed
+    if Profile.__module__ == 'profile':
+        def __init__(self, *args, **kwds):  # noqa: F811
+            raise AssertionError('non-line-by-line profiling depends on '
+                                 'cProfile, which is not available on this '
+                                 'platform')
 
 
 class RepeatedTimer:

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -55,7 +55,7 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
         it on function exit.
         """
         self.add_function(func)
-        return ByCountProfilerMixin.__call__(self, func)
+        return self.wrap_callable(func)
 
     def dump_stats(self, filename):
         """ Dump a representation of the data to a file as a pickled LineStats

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -5,7 +5,6 @@ inspect its output. This depends on the :py:mod:`line_profiler._line_profiler`
 Cython backend.
 """
 import pickle
-import functools
 import inspect
 import linecache
 import tempfile
@@ -20,6 +19,7 @@ except ImportError as ex:
         'The line_profiler._line_profiler c-extension is not importable. '
         f'Has it been compiled? Underlying error is ex={ex!r}'
     )
+from .profiler_mixin import ByCountProfilerMixin
 
 # NOTE: This needs to be in sync with ../kernprof.py and __init__.py
 __version__ = '4.3.0'
@@ -32,25 +32,7 @@ def load_ipython_extension(ip):
     ip.register_magics(LineProfilerMagics)
 
 
-def is_coroutine(f):
-    return inspect.iscoroutinefunction(f)
-
-
-CO_GENERATOR = inspect.CO_GENERATOR
-
-
-def is_generator(f):
-    """ Return True if a function is a generator.
-    """
-    isgen = (f.__code__.co_flags & CO_GENERATOR) != 0
-    return isgen
-
-
-def is_classmethod(f):
-    return isinstance(f, classmethod)
-
-
-class LineProfiler(CLineProfiler):
+class LineProfiler(CLineProfiler, ByCountProfilerMixin):
     """
     A profiler that records the execution times of individual lines.
 
@@ -73,85 +55,7 @@ class LineProfiler(CLineProfiler):
         it on function exit.
         """
         self.add_function(func)
-        if is_classmethod(func):
-            wrapper = self.wrap_classmethod(func)
-        elif is_coroutine(func):
-            wrapper = self.wrap_coroutine(func)
-        elif is_generator(func):
-            wrapper = self.wrap_generator(func)
-        else:
-            wrapper = self.wrap_function(func)
-        return wrapper
-
-    def wrap_classmethod(self, func):
-        """
-        Wrap a classmethod to profile it.
-        """
-        @functools.wraps(func)
-        def wrapper(*args, **kwds):
-            self.enable_by_count()
-            try:
-                result = func.__func__(func.__class__, *args, **kwds)
-            finally:
-                self.disable_by_count()
-            return result
-        return wrapper
-
-    def wrap_coroutine(self, func):
-        """
-        Wrap a Python 3.5 coroutine to profile it.
-        """
-
-        @functools.wraps(func)
-        async def wrapper(*args, **kwds):
-            self.enable_by_count()
-            try:
-                result = await func(*args, **kwds)
-            finally:
-                self.disable_by_count()
-            return result
-
-        return wrapper
-
-    def wrap_generator(self, func):
-        """ Wrap a generator to profile it.
-        """
-        @functools.wraps(func)
-        def wrapper(*args, **kwds):
-            g = func(*args, **kwds)
-            # The first iterate will not be a .send()
-            self.enable_by_count()
-            try:
-                item = next(g)
-            except StopIteration:
-                return
-            finally:
-                self.disable_by_count()
-            input_ = (yield item)
-            # But any following one might be.
-            while True:
-                self.enable_by_count()
-                try:
-                    item = g.send(input_)
-                except StopIteration:
-                    return
-                finally:
-                    self.disable_by_count()
-                input_ = (yield item)
-        return wrapper
-
-    def wrap_function(self, func):
-        """ Wrap a function to profile it.
-        """
-        @functools.wraps(func)
-        def wrapper(*args, **kwds):
-            self.enable_by_count()
-            try:
-                result = func(*args, **kwds)
-            finally:
-                self.disable_by_count()
-            return result
-        return wrapper
+        return ByCountProfilerMixin.__call__(self, func)
 
     def dump_stats(self, filename):
         """ Dump a representation of the data to a file as a pickled LineStats
@@ -169,32 +73,6 @@ class LineProfiler(CLineProfiler):
         show_text(lstats.timings, lstats.unit, output_unit=output_unit,
                   stream=stream, stripzeros=stripzeros,
                   details=details, summarize=summarize, sort=sort, rich=rich)
-
-    def run(self, cmd):
-        """ Profile a single executable statment in the main namespace.
-        """
-        import __main__
-        main_dict = __main__.__dict__
-        return self.runctx(cmd, main_dict, main_dict)
-
-    def runctx(self, cmd, globals, locals):
-        """ Profile a single executable statement in the given namespaces.
-        """
-        self.enable_by_count()
-        try:
-            exec(cmd, globals, locals)
-        finally:
-            self.disable_by_count()
-        return self
-
-    def runcall(self, func, *args, **kw):
-        """ Profile a single function call.
-        """
-        self.enable_by_count()
-        try:
-            return func(*args, **kw)
-        finally:
-            self.disable_by_count()
 
     def add_module(self, mod):
         """ Add all the functions in a module and its classes.

--- a/line_profiler/line_profiler.pyi
+++ b/line_profiler/line_profiler.pyi
@@ -2,6 +2,7 @@ from typing import List
 from typing import Tuple
 import io
 from ._line_profiler import LineProfiler as CLineProfiler
+from .profiler_mixin import ByCountProfilerMixin
 from _typeshed import Incomplete
 
 
@@ -9,37 +10,7 @@ def load_ipython_extension(ip) -> None:
     ...
 
 
-def is_coroutine(f):
-    ...
-
-
-CO_GENERATOR: int
-
-
-def is_generator(f):
-    ...
-
-
-def is_classmethod(f):
-    ...
-
-
-class LineProfiler(CLineProfiler):
-
-    def __call__(self, func):
-        ...
-
-    def wrap_classmethod(self, func):
-        ...
-
-    def wrap_coroutine(self, func):
-        ...
-
-    def wrap_generator(self, func):
-        ...
-
-    def wrap_function(self, func):
-        ...
+class LineProfiler(CLineProfiler, ByCountProfilerMixin):
 
     def dump_stats(self, filename) -> None:
         ...
@@ -52,15 +23,6 @@ class LineProfiler(CLineProfiler):
                     summarize: bool = ...,
                     sort: bool = ...,
                     rich: bool = ...) -> None:
-        ...
-
-    def run(self, cmd):
-        ...
-
-    def runctx(self, cmd, globals, locals):
-        ...
-
-    def runcall(self, func, *args, **kw):
         ...
 
     def add_module(self, mod):

--- a/line_profiler/profiler_mixin.py
+++ b/line_profiler/profiler_mixin.py
@@ -19,7 +19,7 @@ class ByCountProfilerMixin:
     Used by `line_profiler.line_profiler.LineProfiler` and
     `kernprof.ContextualProfile`.
     """
-    def __call__(self, func):
+    def wrap_callable(self, func):
         """ Decorate a function to start the profiler on function entry and stop
         it on function exit.
         """

--- a/line_profiler/profiler_mixin.py
+++ b/line_profiler/profiler_mixin.py
@@ -1,0 +1,137 @@
+import functools
+import inspect
+
+
+is_coroutine = inspect.iscoroutinefunction
+is_generator = inspect.isgeneratorfunction
+
+
+def is_classmethod(f):
+    return isinstance(f, classmethod)
+
+
+class ByCountProfilerMixin:
+    """
+    Mixin class for profiler methods built around the
+    `.enable_by_count()` and `.disable_by_count()` methods, rather than
+    the `.enable()` and `.disable()` methods.
+
+    Used by `line_profiler.line_profiler.LineProfiler` and
+    `kernprof.ContextualProfile`.
+    """
+    def __call__(self, func):
+        """ Decorate a function to start the profiler on function entry and stop
+        it on function exit.
+        """
+        if is_classmethod(func):
+            wrapper = self.wrap_classmethod(func)
+        elif is_coroutine(func):
+            wrapper = self.wrap_coroutine(func)
+        elif is_generator(func):
+            wrapper = self.wrap_generator(func)
+        else:
+            wrapper = self.wrap_function(func)
+        return wrapper
+
+    def wrap_classmethod(self, func):
+        """
+        Wrap a classmethod to profile it.
+        """
+        @functools.wraps(func)
+        def wrapper(*args, **kwds):
+            self.enable_by_count()
+            try:
+                result = func.__func__(func.__class__, *args, **kwds)
+            finally:
+                self.disable_by_count()
+            return result
+        return wrapper
+
+    def wrap_coroutine(self, func):
+        """
+        Wrap a Python 3.5 coroutine to profile it.
+        """
+
+        @functools.wraps(func)
+        async def wrapper(*args, **kwds):
+            self.enable_by_count()
+            try:
+                result = await func(*args, **kwds)
+            finally:
+                self.disable_by_count()
+            return result
+
+        return wrapper
+
+    def wrap_generator(self, func):
+        """ Wrap a generator to profile it.
+        """
+        @functools.wraps(func)
+        def wrapper(*args, **kwds):
+            g = func(*args, **kwds)
+            # The first iterate will not be a .send()
+            self.enable_by_count()
+            try:
+                item = next(g)
+            except StopIteration:
+                return
+            finally:
+                self.disable_by_count()
+            input_ = (yield item)
+            # But any following one might be.
+            while True:
+                self.enable_by_count()
+                try:
+                    item = g.send(input_)
+                except StopIteration:
+                    return
+                finally:
+                    self.disable_by_count()
+                input_ = (yield item)
+        return wrapper
+
+    def wrap_function(self, func):
+        """ Wrap a function to profile it.
+        """
+        @functools.wraps(func)
+        def wrapper(*args, **kwds):
+            self.enable_by_count()
+            try:
+                result = func(*args, **kwds)
+            finally:
+                self.disable_by_count()
+            return result
+        return wrapper
+
+    def run(self, cmd):
+        """ Profile a single executable statment in the main namespace.
+        """
+        import __main__
+        main_dict = __main__.__dict__
+        return self.runctx(cmd, main_dict, main_dict)
+
+    def runctx(self, cmd, globals, locals):
+        """ Profile a single executable statement in the given namespaces.
+        """
+        self.enable_by_count()
+        try:
+            exec(cmd, globals, locals)
+        finally:
+            self.disable_by_count()
+        return self
+
+    def runcall(self, func, /, *args, **kw):
+        """ Profile a single function call.
+        """
+        self.enable_by_count()
+        try:
+            return func(*args, **kw)
+        finally:
+            self.disable_by_count()
+
+    def __enter__(self):
+        self.enable_by_count()
+        return self
+
+    def __exit__(self, *_, **__):
+        self.disable_by_count()

--- a/line_profiler/profiler_mixin.pyi
+++ b/line_profiler/profiler_mixin.pyi
@@ -11,7 +11,7 @@ def is_classmethod(f) -> bool:
 
 class ByCountProfilerMixin:
 
-    def __call__(self, func):
+    def wrap_callable(self, func):
         ...
 
     def wrap_classmethod(self, func):

--- a/line_profiler/profiler_mixin.pyi
+++ b/line_profiler/profiler_mixin.pyi
@@ -1,0 +1,42 @@
+import inspect
+
+
+is_coroutine = inspect.iscoroutinefunction
+is_generator = inspect.isgeneratorfunction
+
+
+def is_classmethod(f) -> bool:
+    ...
+
+
+class ByCountProfilerMixin:
+
+    def __call__(self, func):
+        ...
+
+    def wrap_classmethod(self, func):
+        ...
+
+    def wrap_coroutine(self, func):
+        ...
+
+    def wrap_generator(self, func):
+        ...
+
+    def wrap_function(self, func):
+        ...
+
+    def run(self, cmd):
+        ...
+
+    def runctx(self, cmd, globals, locals):
+        ...
+
+    def runcall(self, func, /, *args, **kw):
+        ...
+
+    def __enter__(self):
+        ...
+
+    def __exit__(self, *_, **__):
+        ...


### PR DESCRIPTION
Synopsis
----

When writing #323, we noticed that the one of the new tests are failing in Python 3.12 and above, and accidentally discovered that the `prof.runctx()` code path is currently untested. Said code path is executed when `kernprof` is run with neither the `-b`/`--builtin` nor `-l`/`--line-by-line` options. 

Further investigation revealed that the introduction of `sys.monitoring` and tooling registration is to blame, especially [these lines in `lsprof.c`](https://github.com/python/cpython/blob/c1e708ab070a08a4427e230dd9127138d527ceef/Modules/_lsprof.c#L757-761) of the Python source code, corresponding to `cProfile.Profile.enable()` – which causes `kernprof.ContextualProfile.enable_by_count()` to fail when first called, because the profiling tool `'cProfile'` has already been registered to `sys.monitoring.use_tool_id()`.

~~This PR adds a check which frees the tool ID if registered, so that it can be re-registered by `.enable()` when `.enable_by_count()` is called.~~

**EDIT 22 Mar**: This PR refactors `kernprof.ContextualProfile` so that:
- Its `.run()`, `.runctx()`, and `.runcall()` methods no longer directly call `.enable()` and `.disable()`, but `.enable_by_count()` and `.disable_by_count()` instead;
- The methods shared between it and `line_profiler.LineProfiler` are moved into a separate mix-in class, which both now inherit from.
- ~~`.__init__()` now raises an error when `cProfile.Profile` is unavailable and `profile.Profile` is loaded as a base class instead, because of API incompatibilities (see [comment below](#issuecomment-2745035860)).~~

**EDIT 1 Apr**: the error raised by `ContextualProfile.__init__()` has been migrated to `kernprof.main()`.

Caveats
----

When messing around with the code, the following potential bug is noted; ~~but since it may be a while before we can come up with a robust fix, I decided to let that be and maybe fix/write an issue later.~~

Specifically, `profile.Profile` may be imported as a substitute for `cProfile.Profile`. However, the former is not fully compatible with `kernprof.ContextualProfile`, because it [cannot be `.enable()`-ed nor `.disable()`-ed](https://docs.python.org/3/library/profile.html#profile.Profile.enable). ~~A "fix" seems easy – just don't call those methods if we don't have them – but IDK about the full ramifications of that.~~

**EDIT 22 Mar**: see above edit.