### PR TITLE
ENH: `sys.monitoring` compliance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changes
 4.3.0
 ~~~~~
 * FIX: win32 encoding issues
+* ENH: Add support for ``sys.monitoring`` (Python >= 3.12)
 
 4.2.0
 ~~~~~

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -306,6 +306,12 @@ cdef class LineProfiler:
         self.disable_by_count()
 
     def enable(self):
+        try:
+            mon = sys.monitoring
+        except AttributeError:  # Python < 3.12
+            pass
+        else:
+            mon.use_tool_id(mon.PROFILER_ID, 'line_profiler')
         PyEval_SetTrace(python_trace_callback, self)
 
     @property
@@ -359,6 +365,12 @@ cdef class LineProfiler:
     cpdef disable(self):
         self._c_last_time[threading.get_ident()].clear()
         unset_trace()
+        try:
+            mon = sys.monitoring
+        except AttributeError:  # Python < 3.12
+            pass
+        else:
+            mon.free_tool_id(mon.PROFILER_ID)
 
     def get_stats(self):
         """

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -129,9 +129,15 @@ cdef inline int64 compute_line_hash(uint64 block_hash, uint64 linenum):
 
 
 if PY_VERSION_HEX < 0x030c00b1:  # 3.12.0b1
-    def _sys_monitoring_register() -> None: ...
-    def _sys_monitoring_deregister() -> None: ...
+
+    def _sys_monitoring_register() -> None: 
+        ...
+
+    def _sys_monitoring_deregister() -> None: 
+        ...
+
 else:
+
     def _is_main_thread() -> bool:
         return threading.current_thread() == threading.main_thread()
 
@@ -476,5 +482,3 @@ cdef extern int python_trace_callback(object self_, PyFrameObject *py_frame,
                 self._c_last_time[ident].erase(self._c_last_time[ident].find(block_hash))
 
     return 0
-
-

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -159,13 +159,17 @@ cdef extern from "Python.h":
          PyObject* monitoring = PyImport_ImportModuleAttrString("sys",
                                                                 "monitoring");
          if (!monitoring) return;
-         PyObject *check = PyObject_CallMethod(monitoring,
+         PyObject* check = PyObject_CallMethod(monitoring,
                                                "use_tool_id",
                                                "is",
                                                PY_MONITORING_PROFILER_ID,
                                                "line_profiler");
-         if (check == NULL) PyErr_Format(
-             PyExc_ValueError, "Another profiling tool is already active");
+         if (!check) {
+            PyErr_Format(PyExc_ValueError,
+                         "Another profiling tool is already active");
+         } else {
+            Py_DECREF(check);
+         }
          Py_DECREF(monitoring);
          return;
       }
@@ -175,10 +179,16 @@ cdef extern from "Python.h":
          PyObject* monitoring = PyImport_ImportModuleAttrString("sys",
                                                                 "monitoring");
          if (!monitoring) return;
-         PyObject *result = PyObject_CallMethod(monitoring,
+         PyObject* result = PyObject_CallMethod(monitoring,
                                                 "free_tool_id",
                                                 "i",
                                                 PY_MONITORING_PROFILER_ID);
+         if (!result) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "Error freeing the profiling tool ID");
+         } else {
+            Py_DECREF(result);
+         }
          Py_DECREF(monitoring);
          return;
       }
@@ -188,7 +198,7 @@ cdef extern from "Python.h":
     #endif
     """
     cdef void _sys_monitoring_register() except *
-    cdef void _sys_monitoring_deregister()
+    cdef void _sys_monitoring_deregister() except *
     
 cdef extern from "timers.c":
     PY_LONG_LONG hpTimer()

--- a/tests/test_complex_case.py
+++ b/tests/test_complex_case.py
@@ -1,11 +1,7 @@
 import os
 import sys
 import tempfile
-
-import pytest
 import ubelt as ub
-
-
 LINUX = sys.platform.startswith('linux')
 
 
@@ -29,7 +25,14 @@ def test_complex_example_python_none():
     info.check_returncode()
 
 
-def build_parametrizer():
+def test_varied_complex_invocations():
+    """
+    Tests variations of running the complex example:
+        with / without kernprof
+        with cProfile / LineProfiler backends
+        with / without explicit profiler
+    """
+
     # Enumerate valid cases to test
     cases = []
     for runner in ['python',  'kernprof']:
@@ -82,78 +85,64 @@ def build_parametrizer():
             'outpath': 'complex_example.py.lprof',
         })
 
-    params = ('runner', 'kern_flags', 'env_line_profile', 'profile_type',
-              'outpath', 'ignore_checks')
-    return pytest.mark.parametrize(
-        params, [tuple(case.get(param) for param in params) for case in cases])
-
-
-@build_parametrizer()
-def test_varied_complex_invocations(
-        runner, kern_flags, env_line_profile, profile_type,
-        outpath, ignore_checks):
-    """
-    Tests variations of running the complex example:
-        with / without kernprof
-        with cProfile / LineProfiler backends
-        with / without explicit profiler
-    """
-
     complex_fpath = get_complex_example_fpath()
 
     results = []
 
-    temp_dpath = tempfile.mkdtemp()
-    with ub.ChDir(temp_dpath):
-        env = {}
+    for case in cases:
+        temp_dpath = tempfile.mkdtemp()
+        with ub.ChDir(temp_dpath):
+            env = {}
 
-        if outpath:
-            outpath = ub.Path(outpath)
+            outpath = case['outpath']
+            if outpath:
+                outpath = ub.Path(outpath)
 
-        # Construct the invocation for each case
-        if runner == 'kernprof':
-            # FIXME:
-            # Note: kernprof doesn't seem to play well with multiprocessing
-            prog_flags = ' --process_size=0'
-            runner = f'{sys.executable} -m kernprof {kern_flags}'
-        else:
-            env['LINE_PROFILE'] = env_line_profile
-            runner = f'{sys.executable}'
-            prog_flags = ''
-        env['PROFILE_TYPE'] = profile_type
-        command = f'{runner} {complex_fpath}' + prog_flags
+            # Construct the invocation for each case
+            if case['runner'] == 'kernprof':
+                kern_flags = case['kern_flags']
+                # FIXME:
+                # Note: kernprof doesn't seem to play well with multiprocessing
+                prog_flags = ' --process_size=0'
+                runner = f'{sys.executable} -m kernprof {kern_flags}'
+            else:
+                env['LINE_PROFILE'] = case["env_line_profile"]
+                runner = f'{sys.executable}'
+                prog_flags = ''
+            env['PROFILE_TYPE'] = case["profile_type"]
+            command = f'{runner} {complex_fpath}' + prog_flags
 
-        HAS_SHELL = LINUX
-        if HAS_SHELL:
-            # Use shell because it gives a indication of what is happening
-            environ_prefix = ' '.join([f'{k}={v}' for k, v in env.items()])
-            info = ub.cmd(environ_prefix + ' ' + command, shell=True, verbose=3)
-        else:
-            env = ub.udict(os.environ) | env
-            info = ub.cmd(command, env=env, verbose=3)
+            HAS_SHELL = LINUX
+            if HAS_SHELL:
+                # Use shell because it gives a indication of what is happening
+                environ_prefix = ' '.join([f'{k}={v}' for k, v in env.items()])
+                info = ub.cmd(environ_prefix + ' ' + command, shell=True, verbose=3)
+            else:
+                env = ub.udict(os.environ) | env
+                info = ub.cmd(command, env=env, verbose=3)
 
-        info.check_returncode()
+            info.check_returncode()
 
-        result = {'outpath': outpath}
-        if outpath:
-            result['outsize'] = outpath.stat().st_size
-        else:
-            result['outsize'] = None
-        results.append(result)
+            result = case.copy()
+            if outpath:
+                result['outsize'] = outpath.stat().st_size
+            else:
+                result['outsize'] = None
+            results.append(result)
 
-        if outpath:
-            assert outpath.exists()
-            assert outpath.is_file()
-            outpath.delete()
+            if outpath:
+                assert outpath.exists()
+                assert outpath.is_file()
+                outpath.delete()
 
-        if 0:
-            import pandas as pd
-            import rich
-            table = pd.DataFrame(results)
-            rich.print(table)
+            if 0:
+                import pandas as pd
+                import rich
+                table = pd.DataFrame(results)
+                rich.print(table)
 
-        # Ensure the scripts that produced output produced non-trivial output
-        if not ignore_checks:
-            for result in results:
-                if result['outpath'] is not None:
-                    assert result['outsize'] > 100
+            # Ensure the scripts that produced output produced non-trivial output
+            if not case.get('ignore_checks', False):
+                for result in results:
+                    if result['outpath'] is not None:
+                        assert result['outsize'] > 100

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -1,5 +1,4 @@
 import sys
-
 import pytest
 from line_profiler import LineProfiler
 
@@ -15,7 +14,7 @@ def g(x):
     yield y + 20
 
 
-def h():
+def get_profiling_tool_name():
     return sys.monitoring.get_tool(sys.monitoring.PROFILER_ID)
 
 
@@ -169,6 +168,17 @@ def test_sys_monitoring():
     `sys.monitoring`.
     """
     profile = LineProfiler()
-    h_wrapped = profile(h)
-    assert h_wrapped() == 'line_profiler'
-    assert h() is None
+    get_name_wrapped = profile(get_profiling_tool_name)
+    tool = get_profiling_tool_name()
+    assert tool is None, (
+        f'Expected no active profiling tool before profiling, got {tool!r}'
+    )
+    tool = get_name_wrapped()
+    assert tool == 'line_profiler', (
+        "Expected 'line_profiler' to be registered with `sys.monitoring` "
+        f'when a profiled function is run, got {tool!r}'
+    )
+    tool = get_profiling_tool_name()
+    assert tool is None, (
+        f'Expected no active profiling tool after profiling, got {tool!r}'
+    )

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from line_profiler import LineProfiler
 
@@ -11,6 +13,10 @@ def f(x):
 def g(x):
     y = yield x + 10
     yield y + 20
+
+
+def h():
+    return sys.monitoring.get_tool(sys.monitoring.PROFILER_ID)
 
 
 class C:
@@ -29,7 +35,7 @@ def test_init():
     assert lp.code_map == {f.__code__: {}}
     lp = LineProfiler(f, g)
     assert lp.functions == [f, g]
-    assert lp.code_map ==  {
+    assert lp.code_map == {
         f.__code__: {},
         g.__code__: {},
     }
@@ -152,3 +158,17 @@ def test_show_func_column_formatting():
     print(text)
 
     # TODO: write a check to verify columns are aligned nicely
+
+
+@pytest.mark.skipif(not hasattr(sys, 'monitoring'),
+                    reason='no `sys.monitoring` in version '
+                    f'{".".join(str(v) for v in sys.version_info[:2])}')
+def test_sys_monitoring():
+    """
+    Test that `LineProfiler` is properly registered with
+    `sys.monitoring`.
+    """
+    profile = LineProfiler()
+    h_wrapped = profile(h)
+    assert h_wrapped() == 'line_profiler'
+    assert h() is None


### PR DESCRIPTION
Background
----

This came up during the discussion around #326. Since Python 3.12, profiling tools (like `cProfile.Profile`) are supposed to register themselves with `sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, ...)` when in use, and `sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)` when done.

This seemed like a trivial addition, but doing so naïvely caused `tests/test_complex_case.py::test_varied_complex_invocations()` to fail, presumably due to complications from the test script's use of concurrency. Trying to debug it was difficult, particularly since the singular test was essentially 11 in a trenchcoat.

The PR
----

Hence, this (draft) PR: 
- Refactors `tests/test_complex_case.py::test_varied_complex_invocations()` into a parametrized test, which allows the 11 subtests to be tested separately.
- Adds to the Cython code of `line_profiler/_line_profiler.pyx::LineProfiler.{en,dis}able()` the `sys.monitoring` hooks; when calling `use_tool_id()`, the profiler is registered under the `'line_profiler'` handle.

~~Obviously, the PR is in draft status since the test is still failing.~~

EDIT 22 Mar
----

The test has been fixed and the PR has been un-drafted with the following changes:
- Added new test `tests/test_line_profiler.py::test_sys_monitoring()` to ensure that `LineProfiler` is interacting with `sys.monitoring` in the expected manner.
- Added `CHANGELOG.rst` entry.

Caveats
----

Notably, as opposed to `cProfile.Profile`, `profile.Profile` doesn't register itself with `sys.monitoring`, and only uses the `sys.setprofile()` hook (which is intended for profilers written in pure Python). So *maybe* it isn't strictly necessary for us to go through the trouble...?