### PR TITLE
floating point format %5.1g is too restrictives

### DIFF
--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -352,11 +352,11 @@ def show_func(filename, start_lineno, func_name, timings, unit,
 
         time_disp = '%5.1f' % (time * scalar)
         if len(time_disp) > default_column_sizes['time']:
-            time_disp = '%5.1g' % (time * scalar)
+            time_disp = '%5.3g' % (time * scalar)
 
         perhit_disp = '%5.1f' % (float(time) * scalar / nhits)
         if len(perhit_disp) > default_column_sizes['perhit']:
-            perhit_disp = '%5.1g' % (float(time) * scalar / nhits)
+            perhit_disp = '%5.3g' % (float(time) * scalar / nhits)
 
         nhits_disp = "%d" % nhits
         if len(nhits_disp) > default_column_sizes['hits']:


### PR DESCRIPTION
The biggest number to fit into 8 characters (the narrowest perhit field) using `%5.1f` format is `999999.9`
As soon as the number gets bigger it becomes `%5.1g` with the output  `1e+08`.
One decimal digit of precision is way to small and we still have 3 more spare characters (enough for a decimal point and two more digits) to the total width of 8.
It seems reasonable to replace `%5.1g -> %5.3g`