### PR TITLE
Fix: auto-profiling `async def`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changes
 * FIX: win32 encoding issues
 * ENH: Add support for ``sys.monitoring`` (Python >= 3.12)
 * FIX: Fixed issue when calling ``kernprof`` with neither the ``-l`` nor ``-b`` flag; also refactored common methods to ``LineProfiler`` and ``ContextualProfile``
+* FIX: Fixed auto-profiling of async function definitions #330
 
 4.2.0
 ~~~~~

--- a/line_profiler/autoprofile/ast_profile_transformer.py
+++ b/line_profiler/autoprofile/ast_profile_transformer.py
@@ -62,7 +62,7 @@ class AstProfileTransformer(ast.NodeTransformer):
         self._profiled_imports = profiled_imports if profiled_imports is not None else []
         self._profiler_name = profiler_name
 
-    def visit_FunctionDef(self, node):
+    def _visit_func_def(self, node):
         """Decorate functions/methods with profiler.
 
         Checks if the function/method already has a profile_name decorator, if not, it will append
@@ -71,11 +71,11 @@ class AstProfileTransformer(ast.NodeTransformer):
         e.g. @staticmethod.
 
         Args:
-            (_ast.FunctionDef): node
+            node (Union[_ast.FunctionDef, _ast.AsyncFunctionDef]):
                 function/method in the AST
 
         Returns:
-            (_ast.FunctionDef): node
+            (Union[_ast.FunctionDef, _ast.AsyncFunctionDef]): node
                 function/method with profiling decorator
         """
         decor_ids = set()
@@ -87,6 +87,8 @@ class AstProfileTransformer(ast.NodeTransformer):
         if self._profiler_name not in decor_ids:
             node.decorator_list.append(ast.Name(id=self._profiler_name, ctx=ast.Load()))
         return self.generic_visit(node)
+
+    visit_FunctionDef = visit_AsyncFunctionDef = _visit_func_def
 
     def _visit_import(self, node):
         """Add a node that profiles an import

--- a/line_profiler/autoprofile/ast_profile_transformer.pyi
+++ b/line_profiler/autoprofile/ast_profile_transformer.pyi
@@ -18,7 +18,11 @@ class AstProfileTransformer(ast.NodeTransformer):
                  profiler_name: str = 'profile') -> None:
         ...
 
-    def visit_FunctionDef(self, node) -> (_ast.FunctionDef):
+    def visit_FunctionDef(self, node: _ast.FunctionDef) -> (_ast.FunctionDef):
+        ...
+
+    def visit_AsyncFunctionDef(
+            self, node: _ast.AsyncFunctionDef) -> (_ast.AsyncFunctionDef):
         ...
 
     def visit_Import(


### PR DESCRIPTION
Closes #330.

- `CHANGELOG.rst`:  
  Added entry

- `line_profiler/autoprofile/ast_profile_transformer.py[i]::AstProfileTransformer.visit_AsyncFunctionDef()`:  
  New method (shares the same implementation with `.visit_FunctionDef()`) so that the transformer knows to also decorate `async def` statements

- `tests/test_autoprofile.py::test_async_func_autoprofile()`:  
  Test for auto-profiling of async functions (fails on main, passes wth this fix)