### PR TITLE
FIX: (+ENH?) fixed and extended dispatching for `LineProfiler.__call__()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changes
 * FIX: Fixed issue when calling ``kernprof`` with neither the ``-l`` nor ``-b`` flag; also refactored common methods to ``LineProfiler`` and ``ContextualProfile``
 * FIX: Fixed auto-profiling of async function definitions #330
 * ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script; also made it possible for profiling targets to be supplied across multiple ``-p`` flags
+* FIX: Fixed explicit profiling of class methods; added handling for profiling static, bound, and partial methods, ``functools.partial`` objects, (cached) properties, and async generator functions
 
 4.2.0
 ~~~~~

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -28,12 +28,42 @@ from .profiler_mixin import (ByCountProfilerMixin,
 # NOTE: This needs to be in sync with ../kernprof.py and __init__.py
 __version__ = '4.3.0'
 
+is_function = inspect.isfunction
+
 
 def load_ipython_extension(ip):
     """ API for IPython to recognize this module as an IPython extension.
     """
     from .ipython_extension import LineProfilerMagics
     ip.register_magics(LineProfilerMagics)
+
+
+def _get_underlying_functions(func):
+    """
+    Get the underlying function objects of a callable or an adjacent
+    object.
+
+    Returns:
+        funcs (list[Callable])
+    """
+    if any(check(func)
+           for check in (is_boundmethod, is_classmethod, is_staticmethod)):
+        return _get_underlying_functions(func.__func__)
+    if any(check(func)
+           for check in (is_partial, is_partialmethod, is_cached_property)):
+        return _get_underlying_functions(func.func)
+    if is_property(func):
+        result = []
+        for impl in func.fget, func.fset, func.fdel:
+            if impl is not None:
+                result.extend(_get_underlying_functions(impl))
+        return result
+    if not callable(func):
+        raise TypeError(f'func = {func!r}: '
+                        f'cannot get functions from {type(func)} objects')
+    if is_function(func):
+        return [func]
+    return [type(func).__call__]
 
 
 class LineProfiler(CLineProfiler, ByCountProfilerMixin):
@@ -60,6 +90,9 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
         start the profiler on function entry and stop it on function
         exit.
         """
+        # Note: if `func` is a `types.FunctionType` which is already
+        # decorated by the profiler, the same object is returned;
+        # otherwise, wrapper objects are always returned.
         self.add_callable(func)
         return self.wrap_callable(func)
 
@@ -67,28 +100,20 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
         """
         Register a function, method, property, partial object, etc. with
         the underlying Cython profiler.
-        """
-        if is_property(func):
-            self.add_property(func)
-        elif any(check(func)
-                 for check in (is_boundmethod,
-                               is_classmethod, is_staticmethod)):
-            self.add_function(func.__func__)
-        elif any(check(func) for check in (is_partial, is_partialmethod,
-                                           is_cached_property)):
-            self.add_function(func.func)
-        else:
-            self.add_function(func)
 
-    def add_property(self, func):
+        Returns:
+            1 if any function is added to the profiler, 0 otherwise
         """
-        Register a `property`'s getter, setter, and deleter
-        implementations with the underlying Cython profiler.
-        """
-        for impl in func.fget, func.fset, func.fdel:
-            if impl is None:
+        guard = self._already_wrapped
+
+        nadded = 0
+        for impl in _get_underlying_functions(func):
+            if guard(impl):
                 continue
             self.add_function(impl)
+            nadded += 1
+
+        return 1 if nadded else 0
 
     def dump_stats(self, filename):
         """ Dump a representation of the data to a file as a pickled LineStats
@@ -110,16 +135,16 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
     def add_module(self, mod):
         """ Add all the functions in a module and its classes.
         """
-        from inspect import isclass, isfunction
+        from inspect import isclass
 
         nfuncsadded = 0
         for item in mod.__dict__.values():
             if isclass(item):
                 for k, v in item.__dict__.items():
-                    if isfunction(v):
+                    if is_function(v):
                         self.add_function(v)
                         nfuncsadded += 1
-            elif isfunction(item):
+            elif is_function(item):
                 self.add_function(item)
                 nfuncsadded += 1
 

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -55,8 +55,18 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
     """
 
     def __call__(self, func):
-        """ Decorate a function to start the profiler on function entry and stop
-        it on function exit.
+        """
+        Decorate a function, method, property, partial object etc. to
+        start the profiler on function entry and stop it on function
+        exit.
+        """
+        self.add_callable(func)
+        return self.wrap_callable(func)
+
+    def add_callable(self, func):
+        """
+        Register a function, method, property, partial object, etc. with
+        the underlying Cython profiler.
         """
         if is_property(func):
             self.add_property(func)
@@ -69,9 +79,12 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
             self.add_function(func.func)
         else:
             self.add_function(func)
-        return self.wrap_callable(func)
 
     def add_property(self, func):
+        """
+        Register a `property`'s getter, setter, and deleter
+        implementations with the underlying Cython profiler.
+        """
         for impl in func.fget, func.fset, func.fdel:
             if impl is None:
                 continue

--- a/line_profiler/line_profiler.pyi
+++ b/line_profiler/line_profiler.pyi
@@ -15,9 +15,6 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
     def add_callable(self, func) -> None:
         ...
 
-    def add_property(self, func) -> None:
-        ...
-
     def dump_stats(self, filename) -> None:
         ...
 

--- a/line_profiler/line_profiler.pyi
+++ b/line_profiler/line_profiler.pyi
@@ -12,6 +12,9 @@ def load_ipython_extension(ip) -> None:
 
 class LineProfiler(CLineProfiler, ByCountProfilerMixin):
 
+    def add_property(self, func) -> None:
+        ...
+
     def dump_stats(self, filename) -> None:
         ...
 

--- a/line_profiler/line_profiler.pyi
+++ b/line_profiler/line_profiler.pyi
@@ -12,6 +12,9 @@ def load_ipython_extension(ip) -> None:
 
 class LineProfiler(CLineProfiler, ByCountProfilerMixin):
 
+    def add_callable(self, func) -> None:
+        ...
+
     def add_property(self, func) -> None:
         ...
 

--- a/line_profiler/profiler_mixin.py
+++ b/line_profiler/profiler_mixin.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import types
 
 
 is_coroutine = inspect.iscoroutinefunction
@@ -8,6 +9,30 @@ is_generator = inspect.isgeneratorfunction
 
 def is_classmethod(f):
     return isinstance(f, classmethod)
+
+
+def is_staticmethod(f):
+    return isinstance(f, staticmethod)
+
+
+def is_boundmethod(f):
+    return isinstance(f, types.MethodType)
+
+
+def is_partialmethod(f):
+    return isinstance(f, functools.partialmethod)
+
+
+def is_partial(f):
+    return isinstance(f, functools.partial)
+
+
+def is_property(f):
+    return isinstance(f, property)
+
+
+def is_cached_property(f):
+    return isinstance(f, functools.cached_property)
 
 
 class ByCountProfilerMixin:
@@ -25,6 +50,18 @@ class ByCountProfilerMixin:
         """
         if is_classmethod(func):
             wrapper = self.wrap_classmethod(func)
+        elif is_staticmethod(func):
+            wrapper = self.wrap_staticmethod(func)
+        elif is_boundmethod(func):
+            wrapper = self.wrap_boundmethod(func)
+        elif is_partialmethod(func):
+            wrapper = self.wrap_partialmethod(func)
+        elif is_partial(func):
+            wrapper = self.wrap_partial(func)
+        elif is_property(func):
+            wrapper = self.wrap_property(func)
+        elif is_cached_property(func):
+            wrapper = self.wrap_cached_property(func)
         elif is_coroutine(func):
             wrapper = self.wrap_coroutine(func)
         elif is_generator(func):
@@ -33,19 +70,125 @@ class ByCountProfilerMixin:
             wrapper = self.wrap_function(func)
         return wrapper
 
-    def wrap_classmethod(self, func):
+    def _wrap_callable_wrapper(self, wrapper, impl_attrs, *,
+                               args=None, kwargs=None, name_attr=None):
         """
-        Wrap a classmethod to profile it.
+        Create a profiled wrapper object around callables based on an
+        existing wrapper.
+
+        Args:
+            wrapper (W):
+                Wrapper object around regular callables, like
+                `property`, `staticmethod`, `functools.partial`, etc.
+            impl_attrs (Sequence[str]):
+                Attribute names whence to retrieve the individual
+                callables to be wrapped and profiled, like `.fget`,
+                `.fset`, and `.fdel` for `property`;
+                the retrieved values are wrapped and passed as
+                positional arguments to the wrapper constructor.
+            args (Optional[str | Sequence[str]]):
+                Optional attribute name or names whence to retrieve
+                extra positional arguments to pass to the wrapper
+                constructor;
+                if a single name, the retrieved value is unpacked;
+                else, each name corresponds to one extra positional arg.
+            kwargs (Optional[str | Mapping[str, str]]):
+                Optional attribute name or name mapping whence to
+                retrieve extra keyword arguments to pass to the wrapper
+                constructor;
+                if a single name, the retrieved values is unpacked;
+                else, the attribute of `wrapper` at the mapping value is
+                used to populate the keyword arg at the mapping key.
+            name_attr (Optional[str]):
+                Optional attribute name whence to retrieve the name of
+                `wrapper` to be carried over in the new wrapper, like
+                `__name__` for `property` (Python 3.13+) and `attrname`
+                for `functools.cached_property`.
+
+        Returns:
+            (W): new wrapper of the type of `wrapper`
         """
-        @functools.wraps(func)
-        def wrapper(*args, **kwds):
-            self.enable_by_count()
+        # Wrap implementations
+        impls = [getattr(wrapper, attr) for attr in impl_attrs]
+        new_impls = [None if impl is None else self.wrap_callable(impl)
+                     for impl in impls]
+
+        # Get additional init args for the constructor
+        if args is None:
+            init_args = ()
+        elif isinstance(args, str):
+            init_args = getattr(wrapper, args)
+        else:
+            init_args = [getattr(wrapper, attr) for attr in args]
+        if kwargs is None:
+            init_kwargs = {}
+        elif isinstance(kwargs, str):
+            init_kwargs = getattr(wrapper, kwargs)
+        else:
+            init_kwargs = {}
+            for name, attr in kwargs.items():
+                try:
+                    init_kwargs[name] = getattr(wrapper, attr)
+                except AttributeError:
+                    pass
+
+        new_wrapper = type(wrapper)(*new_impls, *init_args, **init_kwargs)
+
+        # Metadata: descriptor name, instance dict
+        if name_attr:
             try:
-                result = func.__func__(func.__class__, *args, **kwds)
-            finally:
-                self.disable_by_count()
-            return result
-        return wrapper
+                setattr(new_wrapper, name_attr, getattr(wrapper, name_attr))
+            except AttributeError:
+                pass
+        try:
+            old_vars = vars(wrapper)
+            new_vars = vars(new_wrapper)
+        except TypeError:  # Object doesn't necessarily have a dict
+            pass
+        else:
+            for key, value in old_vars.items():
+                new_vars.setdefault(key, value)
+
+        return new_wrapper
+
+    def _wrap_class_and_static_method(self, func):
+        """
+        Wrap a class/static method to profile it.
+        """
+        return self._wrap_callable_wrapper(func, ('__func__',))
+
+    wrap_classmethod = wrap_staticmethod = _wrap_class_and_static_method
+
+    def wrap_boundmethod(self, func):
+        """
+        Wrap a bound method to profile it.
+        """
+        return self._wrap_callable_wrapper(func, ('__func__',),
+                                           args=('__self__',))
+
+    def _wrap_partial(self, func):
+        """
+        Wrap a `functools.partial[method]` to profile it.
+        """
+        return self._wrap_callable_wrapper(func, ('func',),
+                                           args='args', kwargs='keywords')
+
+    wrap_partial = wrap_partialmethod = _wrap_partial
+
+    def wrap_property(self, func):
+        """
+        Wrap a property to profile it.
+        """
+        return self._wrap_callable_wrapper(func, ('fget', 'fset', 'fdel'),
+                                           kwargs={'doc': '__doc__'},
+                                           name_attr='__name__')
+
+    def wrap_cached_property(self, func):
+        """
+        Wrap a `functools.cached_property` to profile it.
+        """
+        return self._wrap_callable_wrapper(func, ('func',),
+                                           name_attr='attrname')
 
     def wrap_coroutine(self, func):
         """

--- a/line_profiler/profiler_mixin.pyi
+++ b/line_profiler/profiler_mixin.pyi
@@ -1,4 +1,5 @@
 import inspect
+import typing
 
 
 is_coroutine = inspect.iscoroutinefunction
@@ -9,12 +10,54 @@ def is_classmethod(f) -> bool:
     ...
 
 
+def is_staticmethod(f) -> bool:
+    ...
+
+
+def is_boundmethod(f) -> bool:
+    ...
+
+
+def is_partialmethod(f) -> bool:
+    ...
+
+
+def is_partial(f) -> bool:
+    ...
+
+
+def is_property(f) -> bool:
+    ...
+
+
+def is_cached_property(f) -> bool:
+    ...
+
+
 class ByCountProfilerMixin:
 
     def wrap_callable(self, func):
         ...
 
     def wrap_classmethod(self, func):
+        ...
+
+    def wrap_staticmethod(self, func):
+        ...
+
+    def wrap_boundmethod(self, func):
+        ...
+
+    def wrap_partialmethod(self, func):
+        ...
+
+    def wrap_partial(self, func):
+        ...
+
+    def wrap_property(self, func):
+        ...
+
+    def wrap_cached_property(self, func):
         ...
 
     def wrap_coroutine(self, func):

--- a/line_profiler/profiler_mixin.pyi
+++ b/line_profiler/profiler_mixin.pyi
@@ -4,6 +4,7 @@ import typing
 
 is_coroutine = inspect.iscoroutinefunction
 is_generator = inspect.isgeneratorfunction
+is_async_generator = inspect.isasyncgenfunction
 
 
 def is_classmethod(f) -> bool:
@@ -58,6 +59,9 @@ class ByCountProfilerMixin:
         ...
 
     def wrap_cached_property(self, func):
+        ...
+
+    def wrap_async_generator(self, func):
         ...
 
     def wrap_coroutine(self, func):


### PR DESCRIPTION
(Closes #328)

Synopsis
----
This PR:
- Fixes the known bug that explicit decoration/wrapping of class and static (and also bound) methods returns non-instances thereof, resulting in wrong argument bindings.
- Fixes the lack of handling for async generator functions.
- Extends `LineProfiler` so that it can reliably handle decorating the following:
  - `property`, `functools.cached_property`
  - `functools.partial`
  - `functools.partialmethod`
- Adds tests for all of the above.

Motivation
----
- As noted in #328, decorating class and static methods with `LineProfiler` (and by extension `GlobalProfiler`) is currently bugged because the returned object is a regular `types.FunctionType`, which has different behaviors on `.__get__()` compared with the decorated objects.
- It is also noticed that we have a `.wrap_function()`, a `.wrap_generator()`, a `.wrap_coroutine()`, but not a corresponding `.wrap_async_generator()`.
- As noted in [the discussions](https://github.com/pyutils/line_profiler/issues/318#issuecomment-2645914362) of #318, `line_profiler.autoprofile` currently neglects properties on imports. Indeed, it neglects anything that isn't a vanilla `types.FunctionType` (like class and static methods) because of rather conservative `inspect.isfunction()` checks in `line_profiler/autoprofile/line_profiler_utils.py::add_imported_function_or_module()` and `line_profiler/line_profiler.py::LineProfiler.add_module()`.

Implementation
----
- `line_profiler/profiler_mixin.py::ByCountProfilerMixin.wrap_callable()` now dispatches to the following new methods where appropriate:
  - `.wrap_{bound,static,partial}method()`
  - `.wrap_partial()`
  - `.wrap_[cached_]property()`
  - `.wrap_async_generator()`
- Instead of calling `.add_function()` directly, `line_profiler/line_profiler.py::LineProfiler.__call__()` now calls the new `.add_callable()`, which likewise handles dispatch for these object types and passes the underlying function objects to `.add_function()`.
- New tests `tests/test_line_profiler.py::test_{{bound,static,partial}method,[cached_]property,partial,async_gen}_decorator()` for the above.
- New test `tests/test_line_profiler.py::test_coroutine_decorator()` for completeness.
- Updated tests `tests/test_line_profiler.py::test_{function,gen,classmethod}_decorator()` to be more comprehensive and consistent with the new tests.

Caveats
----
The added dispatching may have one-time performance implications. However, as long as we aren't actively adding new items to be profiled by the profiler from *within* the profiled code, it should not impact the profiling results.

Further work
----
By merging this, we can be a bit more liberal with the types of objects we can decorate and/or register with a `LineProfiler`. This opens avenues for the revision of the implementations of the aforementioned `add_imported_function_or_module()` and `add_module()`, allowing e.g. properties and class/static methods to be profiled with `kernprof --prof-mod=...`, `kernprof --prof-imports`, etc.

Though not as thorough as import-time AST rewrites (see [comment](https://github.com/pyutils/line_profiler/pull/323#issuecomment-2799568170)), it will be useful (1) in the meantime before that is integrated, and (2) covering edge cases that AST rewrites may miss.