### PR TITLE
Restore trace callback when the profiler is disabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,10 @@ Changes
     like class methods and properties
   * ``LineProfiler`` can now be used as a class decorator
 * FIX: Fixed line tracing for Cython code; superseded use of the legacy tracing system with ``sys.monitoring``
-* ENH: Fixed edge case where :py:meth:`LineProfiler.get_stats()` neglects data from duplicate code objects (#348)
+* ENH: Fixed edge cases where:
+  * ``LineProfiler.get_stats()`` neglects data from duplicate code objects (#348)
+  * ``LineProfiler`` instances may stop receiving tracing events when multiple instances are used (#350)
+* FIX: ``LineProfiler`` now caches the existing ``sys`` or ``sys.monitoring`` trace callbacks in ``.enable()`` and restores them in ``.disable()``, instead of always discarding it on the way out; also added experimental support for calling (instead of suspending) said callbacks during profiling (#333)
 
 4.2.0
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changes
 * ENH: Highlight final summary using rich if enabled
 * ENH: Made it possible to use multiple profiler instances simultaneously
 * ENH: various improvements related to auto-profiling:
+
   * ``kernprof -p`` target entities are now imported and profiled regardless of
     whether they are directly imported in the run script/module/code (old
     behavior restored by passing ``--no-preimports``)
@@ -25,10 +26,23 @@ Changes
     like class methods and properties
   * ``LineProfiler`` can now be used as a class decorator
 * FIX: Fixed line tracing for Cython code; superseded use of the legacy tracing system with ``sys.monitoring``
-* ENH: Fixed edge cases where:
-  * ``LineProfiler.get_stats()`` neglects data from duplicate code objects (#348)
-  * ``LineProfiler`` instances may stop receiving tracing events when multiple instances are used (#350)
-* FIX: ``LineProfiler`` now caches the existing ``sys`` or ``sys.monitoring`` trace callbacks in ``.enable()`` and restores them in ``.disable()``, instead of always discarding it on the way out; also added experimental support for calling (instead of suspending) said callbacks during profiling (#333)
+* FIX: Fixed edge cases where:
+
+  * ``LineProfiler.get_stats()`` neglected data from duplicate code objects
+    (#348)
+  * ``LineProfiler`` instances may stop receiving tracing events when multiple
+    instances were used (#350)
+  * Line events were not reported for ``raise`` statements and ``finally:``
+    bodies when using ``sys.monitoring`` (#355)
+* FIX: Tracing-system-related fixes (#333):
+
+  * ``LineProfiler`` now caches the existing ``sys`` or ``sys.monitoring`` trace
+    callbacks in ``.enable()`` and restores them in ``.disable()``, instead of
+    always discarding them on the way out
+  * Also added experimental support for calling (instead of suspending) said
+    callbacks during profiling
+  * Now allowing switching back to the "legacy" trace system on Python 3.12+,
+    controlled by an environment variable
 
 4.2.0
 ~~~~~

--- a/docs/source/auto/line_profiler._line_profiler.rst
+++ b/docs/source/auto/line_profiler._line_profiler.rst
@@ -2,6 +2,7 @@ line\_profiler.\_line\_profiler module
 ======================================
 
 .. automodule:: line_profiler._line_profiler
+   :private-members: _LineProfilerManager
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -194,6 +194,9 @@ autosummary_mock_imports = [
     'geowatch.tasks.cold.export_change_map',
 ]
 
+autodoc_default_options = {  # Document callable classes
+    'special-members': '__call__'}
+
 autodoc_member_order = 'bysource'
 autoclass_content = 'both'
 # autodoc_mock_imports = ['torch', 'torchvision', 'visdom']

--- a/line_profiler/CMakeLists.txt
+++ b/line_profiler/CMakeLists.txt
@@ -10,6 +10,7 @@ add_cython_target(${module_name} "${cython_source}" C OUTPUT_VAR sources)
 # Add any other non-cython dependencies to the sources
 list(APPEND sources
   "${CMAKE_CURRENT_SOURCE_DIR}/timers.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/c_trace_callbacks.c"
 )
 message(STATUS "[OURS] sources = ${sources}")
 

--- a/line_profiler/Python_wrapper.h
+++ b/line_profiler/Python_wrapper.h
@@ -5,45 +5,30 @@
 
 #include "Python.h"
 
-/*
- * Ensure PyFrameObject and PyInterpreterState availability as
- * concretely declared structs
- */
-#ifndef Py_BUILD_CORE
-    #define Py_BUILD_CORE 1
-#endif
+// Ensure PyFrameObject availability as a concretely declared struct
 
 // _frame -> PyFrameObject
 #if PY_VERSION_HEX >= 0x030b00a6  // 3.11.0a6
-    #include "internal/pycore_frame.h"
-    #include "cpython/code.h"
-    #include "pyframe.h"
+#   ifndef Py_BUILD_CORE
+#       define Py_BUILD_CORE 1
+#   endif
+#   include "internal/pycore_frame.h"
+#   include "cpython/code.h"
+#   include "pyframe.h"
 #else
-    #include "frameobject.h"
-#endif
-
-// _is -> PyInterpreterState
-#if PY_VERSION_HEX >= 0x030b00a6  // 3.11.0a6
-    #include "pytypedefs.h"
-#else
-    #include "pystate.h"
-#endif
-#if PY_VERSION_HEX >= 0x030900a6  // 3.9.0a6
-    #include "internal/pycore_interp.h"
-#else
-    #include "internal/pycore_pystate.h"
+#   include "frameobject.h"
 #endif
 
 // Backport of Python 3.9 caller hooks
 
 #if PY_VERSION_HEX < 0x030900a4  // 3.9.0a4
-    #define PyObject_CallOneArg(func, arg) \
+#   define PyObject_CallOneArg(func, arg) \
         PyObject_CallFunctionObjArgs(func, arg, NULL)
-    #define PyObject_CallMethodOneArg(obj, name, arg) \
+#   define PyObject_CallMethodOneArg(obj, name, arg) \
         PyObject_CallMethodObjArgs(obj, name, arg, NULL)
-    #define PyObject_CallNoArgs(func) \
+#   define PyObject_CallNoArgs(func) \
         PyObject_CallFunctionObjArgs(func, NULL)
-    #define PyObject_CallMethodNoArgs(obj, name) \
+#   define PyObject_CallMethodNoArgs(obj, name) \
         PyObject_CallMethodObjArgs(obj, name, NULL)
 #endif
 
@@ -54,7 +39,7 @@
      *     INCREF the code object until 0b1 (PR #19773), so override
      *     that for consistency.
      */
-    #define PyFrame_GetCode(x) PyFrame_GetCode_backport(x)
+#   define PyFrame_GetCode(x) PyFrame_GetCode_backport(x)
     inline PyCodeObject *PyFrame_GetCode_backport(PyFrameObject *frame)
     {
         PyCodeObject *code;
@@ -79,12 +64,12 @@
     {
         PyObject *code_bytes;
         if (code == NULL) return NULL;
-        #if PY_VERSION_HEX < 0x030b00a7  // 3.11.0a7
+#       if PY_VERSION_HEX < 0x030b00a7  // 3.11.0a7
             code_bytes = code->co_code;
             Py_XINCREF(code_bytes);
-        #else
+#       else
             code_bytes = PyObject_GetAttrString(code, "co_code");
-        #endif
+#       endif
         return code_bytes;
     }
 #endif

--- a/line_profiler/Python_wrapper.h
+++ b/line_profiler/Python_wrapper.h
@@ -32,6 +32,11 @@
         PyObject_CallMethodObjArgs(obj, name, NULL)
 #endif
 
+#if PY_VERSION_HEX < 0x030900a5  // 3.9.0a5
+#   define PyThreadState_GetInterpreter(tstate) \
+        ((tstate)->interp)
+#endif
+
 #if PY_VERSION_HEX < 0x030900b1  // 3.9.0b1
     /*
      * Notes:

--- a/line_profiler/Python_wrapper.h
+++ b/line_profiler/Python_wrapper.h
@@ -18,6 +18,17 @@
     #include "frameobject.h"
 #endif
 
+#if PY_VERSION_HEX < 0x030900a4  // 3.9.0a4
+    #define PyObject_CallOneArg(func, arg) \
+        PyObject_CallFunctionObjArgs(func, arg, NULL)
+    #define PyObject_CallMethodOneArg(obj, name, arg) \
+        PyObject_CallMethodObjArgs(obj, name, arg, NULL)
+    #define PyObject_CallNoArgs(func) \
+        PyObject_CallFunctionObjArgs(func, NULL)
+    #define PyObject_CallMethodNoArgs(obj, name) \
+        PyObject_CallMethodObjArgs(obj, name, NULL)
+#endif
+
 #if PY_VERSION_HEX < 0x030900b1  // 3.9.0b1
     /*
      * Notes:

--- a/line_profiler/Python_wrapper.h
+++ b/line_profiler/Python_wrapper.h
@@ -5,18 +5,16 @@
 
 #include "Python.h"
 
+// Ensure PyFrameObject availability as a concretely declared struct
 // CPython 3.11 broke some stuff by moving PyFrameObject :(
-#if PY_VERSION_HEX >= 0x030b00a6
+#if PY_VERSION_HEX >= 0x030b00a6  // 3.11.0a6
     #ifndef Py_BUILD_CORE
         #define Py_BUILD_CORE 1
     #endif
     #include "internal/pycore_frame.h"
     #include "cpython/code.h"
     #include "pyframe.h"
-#endif
-
-// Ensure PyFrameObject availability
-#if PY_VERSION_HEX < 0x030900b1  // 3.9.0b1
+#else
     #include "frameobject.h"
 #endif
 

--- a/line_profiler/Python_wrapper.h
+++ b/line_profiler/Python_wrapper.h
@@ -1,0 +1,79 @@
+// Compatibility layer over `Python.h`.
+
+#ifndef LINE_PROFILER_PYTHON_WRAPPER_H
+#define LINE_PROFILER_PYTHON_WRAPPER_H
+
+#include "Python.h"
+
+// CPython 3.11 broke some stuff by moving PyFrameObject :(
+#if PY_VERSION_HEX >= 0x030b00a6
+    #ifndef Py_BUILD_CORE
+        #define Py_BUILD_CORE 1
+    #endif
+    #include "internal/pycore_frame.h"
+    #include "cpython/code.h"
+    #include "pyframe.h"
+#endif
+
+// Ensure PyFrameObject availability
+#if PY_VERSION_HEX < 0x030900b1  // 3.9.0b1
+    #include "frameobject.h"
+#endif
+
+#if PY_VERSION_HEX < 0x030900b1  // 3.9.0b1
+    /*
+     * Notes:
+     *     While 3.9.0a1 already has `PyFrame_GetCode()`, it doesn't
+     *     INCREF the code object until 0b1 (PR #19773), so override
+     *     that for consistency.
+     */
+    #define PyFrame_GetCode(x) PyFrame_GetCode_backport(x)
+    inline PyCodeObject *PyFrame_GetCode_backport(PyFrameObject *frame)
+    {
+        PyCodeObject *code;
+        assert(frame != NULL);
+        code = frame->f_code;
+        assert(code != NULL);
+        Py_INCREF(code);
+        return code;
+    }
+#endif
+
+#if PY_VERSION_HEX < 0x030B00b1  // 3.11.0b1
+    /*
+     * Notes:
+     *     Since 3.11.0a7 (PR #31888) `co_code` has been made a
+     *     descriptor, so:
+     *     - This already creates a NewRef, so don't INCREF in that
+     *       case; and
+     *     - `code->co_code` will not work.
+     */
+    inline PyObject *PyCode_GetCode(PyCodeObject *code)
+    {
+        PyObject *code_bytes;
+        if (code == NULL) return NULL;
+        #if PY_VERSION_HEX < 0x030B00a7  // 3.11.0a7
+            code_bytes = code->co_code;
+            Py_XINCREF(code_bytes);
+        #else
+            code_bytes = PyObject_GetAttrString(code, "co_code");
+        #endif
+        return code_bytes;
+    }
+#endif
+
+#if PY_VERSION_HEX < 0x030D00a1  // 3.13.0a1
+    inline PyObject *PyImport_AddModuleRef(const char *name)
+    {
+        PyObject *mod = NULL, *name_str = NULL;
+        name_str = PyUnicode_FromString(name);
+        if (name_str == NULL) goto cleanup;
+        mod = PyImport_AddModuleObject(name_str);
+        Py_XINCREF(mod);
+    cleanup:
+        Py_XDECREF(name_str);
+        return mod;
+    }
+#endif
+
+#endif // LINE_PROFILER_PYTHON_WRAPPER_H

--- a/line_profiler/_diagnostics.py
+++ b/line_profiler/_diagnostics.py
@@ -7,6 +7,7 @@ import sys
 from types import ModuleType
 from line_profiler import _logger
 
+
 def _boolean_environ(
         envvar,
         truey=frozenset({'1', 'on', 'true', 'yes'}),
@@ -94,9 +95,9 @@ _MUST_USE_LEGACY_TRACE = not isinstance(
 USE_LEGACY_TRACE = (
     _MUST_USE_LEGACY_TRACE
     or _boolean_environ('LINE_PROFILER_CORE',
-                       # Also provide `coverage-style` aliases
-                       truey={'old', 'legacy', 'ctrace'},
-                       falsy={'new', 'sys.monitoring', 'sysmon'},
-                       default=_MUST_USE_LEGACY_TRACE))
+                        # Also provide `coverage-style` aliases
+                        truey={'old', 'legacy', 'ctrace'},
+                        falsy={'new', 'sys.monitoring', 'sysmon'},
+                        default=_MUST_USE_LEGACY_TRACE))
 
 log = _logger.Logger('line_profiler', backend='auto')

--- a/line_profiler/_diagnostics.py
+++ b/line_profiler/_diagnostics.py
@@ -2,26 +2,101 @@
 Global state initialized at import time.
 Used for hidden arguments and developer features.
 """
-from line_profiler import _logger
 import os
+import sys
+from types import ModuleType
+from line_profiler import _logger
 
-
-def _boolean_environ(key):
-    """
+def _boolean_environ(
+        envvar,
+        truey=frozenset({'1', 'on', 'true', 'yes'}),
+        falsy=frozenset({'0', 'off', 'false', 'no'}),
+        default=False):
+    r"""
     Args:
-        key (str)
+        envvar (str)
+            Name for the environment variable to read from.
+        truey (Collection[str])
+            Values to be considered truey.
+        falsy (Collection[str])
+            Values to be considered falsy.
+        default (bool)
+            Default boolean value to resolve to.
 
     Returns:
-        bool
+        :py:data:`True`
+            If the (case-normalized) environment variable is equal to
+            any of ``truey``.
+        :py:data:`False`
+            If the (case-normalized) environment variable is equal to
+            any of ``falsy``.
+        ``default``
+            Otherwise.
+
+    Example:
+        >>> from os import environ
+        >>> from subprocess import run
+        >>> from sys import executable
+        >>> from textwrap import dedent
+        >>>
+        >>>
+        >>> def resolve_in_subproc(value, default,
+        ...                        envvar='MY_ENVVAR',
+        ...                        truey=('foo',), falsy=('bar',)):
+        ...     code = dedent('''
+        ...     from {0.__module__} import {0.__name__}
+        ...     print({0.__name__}({1!r}, {2!r}, {3!r}, {4!r}))
+        ...     ''').strip('\n').format(_boolean_environ, envvar,
+        ...                             tuple(truey), tuple(falsy),
+        ...                             bool(default))
+        ...     env = environ.copy()
+        ...     env[envvar] = value
+        ...     proc = run([executable, '-c', code],
+        ...                capture_output=True, env=env, text=True)
+        ...     proc.check_returncode()
+        ...     return {'True': True,
+        ...             'False': False}[proc.stdout.strip()]
+        ...
+        >>>
+        >>> # Truey value
+        >>> assert resolve_in_subproc('FOO', True) == True
+        >>> assert resolve_in_subproc('FOO', False) == True
+        >>> # Falsy value
+        >>> assert resolve_in_subproc('BaR', True) == False
+        >>> assert resolve_in_subproc('BaR', False) == False
+        >>> # Mismatch -> fall back to default
+        >>> assert resolve_in_subproc('baz', True) == True
+        >>> assert resolve_in_subproc('baz', False) == False
     """
-    value = os.environ.get(key, '').lower()
-    TRUTHY_ENVIRONS = {'true', 'on', 'yes', '1'}
-    return value in TRUTHY_ENVIRONS
+    # (TODO: migrate to `line_profiler.cli_utils.boolean()` after
+    # merging #335)
+    try:
+        value = os.environ.get(envvar).casefold()
+    except AttributeError:  # None
+        return default
+    non_default_values = falsy if default else truey
+    if value in {v.casefold() for v in non_default_values}:
+        return not default
+    return default
 
 
+# `kernprof` switches
 DEBUG = _boolean_environ('LINE_PROFILER_DEBUG')
 NO_EXEC = _boolean_environ('LINE_PROFILER_NO_EXEC')
 KEEP_TEMPDIRS = _boolean_environ('LINE_PROFILER_KEEP_TEMPDIRS')
 STATIC_ANALYSIS = _boolean_environ('LINE_PROFILER_STATIC_ANALYSIS')
+
+# `line_profiler._line_profiler` switches
+WRAP_TRACE = _boolean_environ('LINE_PROFILER_WRAP_TRACE')
+SET_FRAME_LOCAL_TRACE = _boolean_environ('LINE_PROFILER_SET_FRAME_LOCAL_TRACE')
+_MUST_USE_LEGACY_TRACE = not isinstance(
+    getattr(sys, 'monitoring', None), ModuleType)
+USE_LEGACY_TRACE = (
+    _MUST_USE_LEGACY_TRACE
+    or _boolean_environ('LINE_PROFILER_CORE',
+                       # Also provide `coverage-style` aliases
+                       truey={'old', 'legacy', 'ctrace'},
+                       falsy={'new', 'sys.monitoring', 'sysmon'},
+                       default=_MUST_USE_LEGACY_TRACE))
 
 log = _logger.Logger('line_profiler', backend='auto')

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -202,7 +202,7 @@ def label(code):
     module in Python 2.5.
 
     Note:
-        In Python >= 3.11 we use we return qualname for ``_name``.
+        In Python >= 3.11 we return qualname for ``_name``.
         In older versions of Python we just return name.
     """
     if isinstance(code, str):
@@ -416,7 +416,7 @@ cdef class _LineProfilerManager:
         Calls :c:func:`legacy_trace_callback()`.  If
         :py:func:`sys.gettrace` returns this instance, replaces the
         default C-level trace function :c:func:`trace_trampoline` (see
-        the C implementation of :py:mod:sys`) with
+        the C implementation of :py:mod:`sys`) with
         :c:func:`legacy_trace_callback` to reduce overhead.
 
         Returns;
@@ -761,11 +761,12 @@ cdef class LineProfiler:
     cdef public object threaddata
 
     # These are shared between instances and threads
-    # type: dict[int, _LineProfilerManager], int = thread id
+    # type: ClassVar[dict[int, _LineProfilerManager]], int = thread id
     _managers = {}
-    # type: dict[bytes, int], bytes = bytecode
+    # type: ClassVar[dict[bytes, int]], bytes = bytecode
     _all_paddings = {}
-    # type: dict[int, weakref.WeakSet[LineProfiler]], int = func id
+    # type: ClassVar[dict[int, weakref.WeakSet[LineProfiler]]],
+    # int = func id
     _all_instances_by_funcs = {}
 
     def __init__(self, *functions,

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -174,10 +174,6 @@ cdef inline object multibyte_rstrip(bytes bytecode):
     return (unpadded, npad)
 
 
-cdef inline int is_main_thread():
-    return <int>(threading.current_thread() == threading.main_thread())
-
-
 cdef inline object get_current_callback(int event_id):
     """
     Note:
@@ -337,8 +333,6 @@ cdef class _SysMonitoringState:
         # - Since our callbacks are registered globally for events,
         #   there is no risk of events being disrupted by the wrapped
         #   callback's returning `sys.monitoring.DISABLE`
-        if not is_main_thread():
-            return
         mon = sys.monitoring
 
         # Set prior state
@@ -368,8 +362,6 @@ cdef class _SysMonitoringState:
                 mon.PROFILER_ID, event_id, callback)
 
     cpdef deregister(self):
-        if not is_main_thread():
-            return
         mon = sys.monitoring
         cdef dict wrapped_callbacks = self.callbacks
 

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -556,20 +556,20 @@ sys.monitoring.html#monitoring-event-RERAISE
         """
         Calls |legacy_trace_callback|_.  If :py:func:`sys.gettrace`
         returns this instance, replaces the default C-level trace
-        function :c:func:`trace_trampoline` (see the `C implementation`_
-        of :py:mod:`sys`) with |legacy_trace_callback|_ to reduce
-        overhead.
+        function |trace_trampoline|_ with |legacy_trace_callback|_ to
+        reduce overhead.
 
         Returns;
             manager (_LineProfilerManager):
                 This instance.
 
         .. |legacy_trace_callback| replace:: \
-:c:func:`legacy_trace_callback`
+:c:func:`!legacy_trace_callback`
+        .. |trace_trampoline| replace:: :c:func:`!trace_trampoline`
         .. _legacy_trace_callback: https://github.com/pyutils/\
 line_profiler/blob/main/line_profiler/_line_profiler.pyx
-        .. _C implementation: https://github.com/python/cpython/blob/\
-main/Python/sysmodule.c
+        .. _trace_trampoline: https://github.com/python/cpython/blob/\
+6cb20a219a860eaf687b2d968b41c480c7461909/Python/sysmodule.c#L1124
         """
         cdef int what = {'call': PyTrace_CALL,
                          'exception': PyTrace_EXCEPTION,
@@ -997,9 +997,9 @@ cdef class LineProfiler:
             :py:mod:`sys`).
 
     .. _C implementation: https://github.com/python/cpython/blob/\
-main/Python/sysmodule.c
+6cb20a219a860eaf687b2d968b41c480c7461909/Python/sysmodule.c#L1124
     .. _"legacy" trace system: https://github.com/python/cpython/blob/\
-main/Python/legacy_tracing.c
+3.13/Python/legacy_tracing.c
     """
     cdef unordered_map[int64, unordered_map[int64, LineTime]] _c_code_map
     # Mapping between thread-id and map of LastTime
@@ -1359,10 +1359,6 @@ cdef inline inner_trace_callback(
         int is_line_event, object instances, object code, int lineno):
     """
     The basic building block for the trace callbacks.
-
-    References:
-       https://github.com/python/cpython/blob/de2a4036/Include/cpython/\
-pystate.h#L16
     """
     cdef object prof_
     cdef object bytecode = code.co_code

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -855,7 +855,7 @@ cdef class LineProfiler:
             3.12+), it is impossible for code-local callbacks to disable
             global events, therefore:
 
-            * :py:class:`LineProfiler`s (which listen to events
+            * :py:class:`LineProfiler` instances (which listen to events
               globally) are not affected by a frame's
               :py:attr:`~frame.f_trace`; and
             * The parameter/attribute thus always resolves to

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -559,8 +559,8 @@ sys.monitoring.html#monitoring-event-RERAISE
         function |trace_trampoline|_ with |legacy_trace_callback|_ to
         reduce overhead.
 
-        Returns;
-            manager (_LineProfilerManager):
+        Returns:
+            self (_LineProfilerManager):
                 This instance.
 
         .. |legacy_trace_callback| replace:: \

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -894,15 +894,32 @@ cdef class LineProfiler:
             can also disable events:
 
             * At *specific code locations* by returning
-              :py:data:`sys.monitoring.DISABLE`, and
-            * *Globally* by calling
-              :py:func:`sys.monitoring.set_events`.
+              :py:data:`sys.monitoring.DISABLE`;
+            * By calling :py:func:`sys.monitoring.set_events` and
+              changing the *global event set*; or
+            * By calling :py:func:`sys.monitoring.register_callback` and
+              *replacing itself* with alternative callbacks (or
+              :py:data:`None`).
 
             When that happens, said disabling acts are again suitably
-            intercepted so that line profiling continues, but said
-            callables will no longer receive the corresponding events.
-            Note that locally-disabled events are cleared when
-            :py:func:`sys.monitoring.restart_events` is called.
+            intercepted so that line profiling continues, but:
+
+            * Said callbacks will no longer receive the corresponding
+              events, and
+            * The :py:mod:`sys.monitoring` callbacks and event set are
+              updated correspondingly when the profiler is
+              :py:meth:`.disable`-ed.
+
+            Note that:
+
+            * Events disabled for specific code locations are restored
+              to the wrapped/cached callbacks when
+              :py:func:`sys.monitoring.restart_events` is called, as
+              with when line profiling is not used.
+            * Callbacks which only listen to and alter code-object-local
+              events (via :py:func:`sys.monitoring.set_local_events`) do
+              not interfere with line profiling, and such changes are
+              therefore not intercepted.
 
         * .. _notes-set_frame_local_trace:
 

--- a/line_profiler/c_trace_callbacks.c
+++ b/line_profiler/c_trace_callbacks.c
@@ -220,3 +220,14 @@ cleanup:
     Py_XDECREF(method);
     return;
 }
+
+inline Py_uintptr_t monitoring_restart_version()
+#if PY_VERSION_HEX >= 0x030c00b1  // 3.12.0b1
+{
+    /* Get the `.last_restart_version` of the interpretor state.
+     */
+    return PyThreadState_Get()->interp->last_restart_version;
+}
+#else
+{ return (Py_uintptr_t)0; }  // Dummy implementation
+#endif

--- a/line_profiler/c_trace_callbacks.c
+++ b/line_profiler/c_trace_callbacks.c
@@ -1,0 +1,191 @@
+#include "c_trace_callbacks.h"
+
+#define CYTHON_MODULE "line_profiler._line_profiler"
+#define DISABLE_CALLBACK "disable_line_events"
+#define RAISE_IN_CALL(func_name, xc, const_msg) \
+    PyErr_SetString(xc, \
+                    "in `" CYTHON_MODULE "." func_name "()`: " \
+                    const_msg)
+
+TraceCallback *alloc_callback()
+{
+    /* Heap-allocate a new `TraceCallback`. */
+    TraceCallback *callback = (TraceCallback*)malloc(sizeof(TraceCallback));
+    if (callback == NULL) RAISE_IN_CALL(
+        // If we're here we have bigger fish to fry... but be nice and
+        // raise an error explicitly anyway
+        "alloc_callback",
+        PyExc_MemoryError,
+        "failed to allocate memory for storing the existing "
+        "`sys` trace callback"
+    );
+    return callback;
+}
+
+void free_callback(TraceCallback *callback)
+{
+    /* Free a heap-allocated `TraceCallback`. */
+    if (callback != NULL) free(callback);
+    return;
+}
+
+void fetch_callback(TraceCallback *callback)
+{
+    /* Store the members `.c_tracefunc` and `.c_traceobj` of the
+     * current thread on `callback`.
+     */
+    // Shouldn't happen, but just to be safe
+    if (callback == NULL) return;
+    // No need to `Py_DECREF()` the thread callback, since it isn't a
+    // `PyObject`
+    PyThreadState *thread_state = PyThreadState_Get();
+    callback->c_tracefunc = thread_state->c_tracefunc;
+    callback->c_traceobj = thread_state->c_traceobj;
+    // No need for NULL check with `Py_XINCREF()`
+    Py_XINCREF(callback->c_traceobj);
+    return;
+}
+
+void nullify_callback(TraceCallback *callback)
+{
+    // No need for NULL check with `Py_XDECREF()`
+    Py_XDECREF(callback->c_traceobj);
+    callback->c_tracefunc = NULL;
+    callback->c_traceobj = NULL;
+    return;
+}
+
+void restore_callback(TraceCallback *callback)
+{
+    /* Use `PyEval_SetTrace()` to set the trace callback on the current
+     * thread to be consistent with the `callback`, then nullify the
+     * pointers on `callback`.
+     */
+    // Shouldn't happen, but just to be safe
+    if (callback == NULL) return;
+    PyEval_SetTrace(callback->c_tracefunc, callback->c_traceobj);
+    nullify_callback(callback);
+    return;
+}
+
+inline int is_null_callback(TraceCallback *callback)
+{
+    return (
+        callback == NULL
+        || callback->c_tracefunc == NULL
+        || callback->c_traceobj == NULL
+    );
+}
+
+int call_callback(
+    TraceCallback *callback,
+    PyFrameObject *py_frame,
+    int what,
+    PyObject *arg
+)
+{
+    /* Call the cached trace callback `callback` where appropriate, and
+     * in a "safe" way so that:
+     * - If it alters the `sys` trace callback, or
+     * - If it sets `.f_trace_lines` to false,
+     * said alterations are reverted so as not to hinder profiling.
+     *
+     * Returns:
+     *     - 0 if `callback` is `NULL` or has nullified members;
+     *     - -1 if an error occurs (e.g. when the disabling of line
+     *       events for the frame-local trace function failed);
+     *     - The result of calling said callback otherwise.
+     *
+     * Side effects:
+     *     - If the callback unsets the `sys` callback, the `sys`
+     *       callback is preserved but `callback` itself is nullified.
+     *       This is to comply with what Python usually does: if the
+     *       trace callback errors out, `sys.settrace(None)` is called.
+     *     - If a frame-local callback sets the `.f_trace_lines` to
+     *       false, `.f_trace_lines` is reverted but `.f_trace` is
+     *       wrapped so that it no loger sees line events.
+     *
+     * Notes:
+     *     It is tempting to assume said current callback value to be
+     *     `{ python_trace_callback, <profiler> }`, but remember that
+     *     our callback may very well be called via another callback,
+     *     much like how we call the cached callback via
+     *     `python_trace_callback()`.
+     */
+    TraceCallback before, after;
+    PyObject *mod = NULL, *dle = NULL, *f_trace = NULL;
+    char f_trace_lines;
+    int result;
+
+    if (is_null_callback(callback)) return 0;
+
+    f_trace_lines = py_frame->f_trace_lines;
+    fetch_callback(&before);
+    result = (callback->c_tracefunc)(
+        callback->c_traceobj, py_frame, what, arg
+    );
+
+    // Check if the callback has unset itself; if so, nullify `callback`
+    fetch_callback(&after);
+    if (is_null_callback(&after)) nullify_callback(callback);
+    nullify_callback(&after);
+    restore_callback(&before);
+
+    // Check if a callback has disabled future line events for the
+    // frame, and if so, revert the change while withholding future line
+    // events from the callback
+    if (
+        !(py_frame->f_trace_lines)
+        && f_trace_lines != py_frame->f_trace_lines
+    )
+    {
+        py_frame->f_trace_lines = f_trace_lines;
+        if (py_frame->f_trace != NULL && py_frame->f_trace != Py_None)
+        {
+            // FIXME: can we get more performance by stashing a somewhat
+            // permanent reference to
+            // `line_profiler._line_profiler.disable_line_events()`
+            // somewhere?
+            mod = PyImport_AddModuleRef(CYTHON_MODULE);
+            if (mod == NULL)
+            {
+                RAISE_IN_CALL(
+                    "call_callback",
+                    PyExc_ImportError,
+                    "cannot import `" CYTHON_MODULE "`"
+                );
+                result = -1;
+                goto cleanup;
+            }
+            dle = PyObject_GetAttrString(mod, DISABLE_CALLBACK);
+            if (dle == NULL)
+            {
+                RAISE_IN_CALL(
+                    "call_callback",
+                    PyExc_AttributeError,
+                    "`line_profiler._line_profiler` has no "
+                    "attribute `" DISABLE_CALLBACK "`"
+                );
+                result = -1;
+                goto cleanup;
+            }
+            // Note: DON'T `Py_[X]DECREF()` the pointer! Nothing else is
+            // holding a reference to it.
+            f_trace = PyObject_CallFunctionObjArgs(
+                dle, py_frame->f_trace, NULL
+            );
+            if (f_trace == NULL)
+            {
+                // No need to raise another exception, it's already
+                // raised in the call
+                result = -1;
+                goto cleanup;
+            }
+            py_frame->f_trace = f_trace;
+        }
+    }
+cleanup:
+    Py_XDECREF(mod);
+    Py_XDECREF(dle);
+    return result;
+}

--- a/line_profiler/c_trace_callbacks.h
+++ b/line_profiler/c_trace_callbacks.h
@@ -1,0 +1,36 @@
+#ifndef LINE_PROFILER_C_TRACE_CALLBACKS_H
+#define LINE_PROFILER_C_TRACE_CALLBACKS_H
+
+#include "Python_wrapper.h"
+#include "frameobject.h"
+
+typedef struct TraceCallback
+{
+    /* Notes:
+     *     - These fields are synonymous with the corresponding fields
+     *       in a `PyThreadState` object;
+     *       however, note that `PyThreadState.c_tracefunc` is
+     *       considered a CPython implementation detail.
+     *     - It is necessary to reach into the thread-state internals
+     *       like this, because `sys.gettrace()` only retrieves
+     *       `.c_traceobj`, and is thus only valid for Python-level
+     *       trace callables set via `sys.settrace()` (which implicitly
+     *       sets `.c_tracefunc` to
+     *       `Python/sysmodule.c::trace_trampoline()`).
+     */
+    Py_tracefunc c_tracefunc;
+    PyObject *c_traceobj;
+} TraceCallback;
+
+TraceCallback *alloc_callback();
+void free_callback(TraceCallback *callback);
+void fetch_callback(TraceCallback *callback);
+void restore_callback(TraceCallback *callback);
+int call_callback(
+    TraceCallback *callback,
+    PyFrameObject *py_frame,
+    int what,
+    PyObject *arg
+);
+
+#endif // LINE_PROFILER_C_TRACE_CALLBACKS_H

--- a/line_profiler/c_trace_callbacks.h
+++ b/line_profiler/c_trace_callbacks.h
@@ -4,6 +4,34 @@
 #include "Python_wrapper.h"
 #include "frameobject.h"
 
+/*
+ * XXX: would make better sense to declare `PyInterpreterState` in
+ * "Python_wrapper.h", but the file declaring it causes all sorts of
+ * trouble across various platforms and Python versions... so
+ * - Only include the file if we are actually using it here, i.e. in
+ *   3.12+, and
+ * - Undefine the `_PyGC_FINALIZED()` macro which is removed in 3.13+
+ *   and causes problems in 3.12 (see CPython #105268, #105350, #107348)
+ * Note in any case that we don't actually use `PyInterpreterState`
+ * directly -- we just need its memory layout so that we can refer to
+ * its `.last_restart_version` member
+ */
+
+// _is -> PyInterpreterState
+#if PY_VERSION_HEX >= 0x030c00b1  // 3.12.0b6
+#   ifndef Py_BUILD_CORE
+#       define Py_BUILD_CORE 1
+#   endif
+#   ifdef _PyGC_FINALIZED
+#       undef _PyGC_FINALIZED
+#   endif
+#   if PY_VERSION_HEX >= 0x030900a6  // 3.9.0a6
+#      include "internal/pycore_interp.h"
+#   else
+#      include "internal/pycore_pystate.h"
+#   endif
+#endif
+
 typedef struct TraceCallback
 {
     /* Notes:

--- a/line_profiler/c_trace_callbacks.h
+++ b/line_profiler/c_trace_callbacks.h
@@ -32,5 +32,7 @@ int call_callback(
     int what,
     PyObject *arg
 );
+void set_local_trace(PyObject *manager, PyFrameObject *py_frame);
+Py_uintptr_t monitoring_restart_version();
 
 #endif // LINE_PROFILER_C_TRACE_CALLBACKS_H

--- a/line_profiler/c_trace_callbacks.h
+++ b/line_profiler/c_trace_callbacks.h
@@ -57,9 +57,10 @@ typedef struct TraceCallback
 
 TraceCallback *alloc_callback();
 void free_callback(TraceCallback *callback);
-void fetch_callback(TraceCallback *callback);
+void populate_callback(TraceCallback *callback);
 void restore_callback(TraceCallback *callback);
 int call_callback(
+    PyObject *disabler,
     TraceCallback *callback,
     PyFrameObject *py_frame,
     int what,

--- a/line_profiler/c_trace_callbacks.h
+++ b/line_profiler/c_trace_callbacks.h
@@ -12,6 +12,8 @@
  *   3.12+, and
  * - Undefine the `_PyGC_FINALIZED()` macro which is removed in 3.13+
  *   and causes problems in 3.12 (see CPython #105268, #105350, #107348)
+ * - Undefine the `HAVE_STD_ATOMIC` macro, which causes problems on
+ *   Linux in 3.12 (see CPython #108216)
  * Note in any case that we don't actually use `PyInterpreterState`
  * directly -- we just need its memory layout so that we can refer to
  * its `.last_restart_version` member
@@ -24,6 +26,9 @@
 #   endif
 #   ifdef _PyGC_FINALIZED
 #       undef _PyGC_FINALIZED
+#   endif
+#   ifdef HAVE_STD_ATOMIC
+#       undef HAVE_STD_ATOMIC
 #   endif
 #   if PY_VERSION_HEX >= 0x030900a6  // 3.9.0a6
 #      include "internal/pycore_interp.h"

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,8 @@ if __name__ == '__main__':
                 Extension(
                     name="line_profiler._line_profiler",
                     sources=["line_profiler/_line_profiler.pyx",
-                             "line_profiler/timers.c"],
+                             "line_profiler/timers.c",
+                             "line_profiler/c_trace_callbacks.c"],
                     language="c++",
                     define_macros=[("CYTHON_TRACE", (1 if os.getenv("DEV") == "true" else 0))],
                 ),

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 import types
 import pytest
-from line_profiler import LineProfiler
+from line_profiler import _line_profiler, LineProfiler
 
 
 def f(x):
@@ -680,11 +680,12 @@ def test_show_func_column_formatting():
 @pytest.mark.skipif(not hasattr(sys, 'monitoring'),
                     reason='no `sys.monitoring` in version '
                     f'{".".join(str(v) for v in sys.version_info[:2])}')
-def test_sys_monitoring():
+def test_sys_monitoring(monkeypatch):
     """
     Test that `LineProfiler` is properly registered with
     `sys.monitoring`.
     """
+    monkeypatch.setattr(_line_profiler, 'USE_LEGACY_TRACE', False)
     profile = LineProfiler()
     get_name_wrapped = profile(get_profiling_tool_name)
     tool = get_profiling_tool_name()

--- a/tests/test_sys_monitoring.py
+++ b/tests/test_sys_monitoring.py
@@ -1,0 +1,373 @@
+import inspect
+import sys
+from collections import Counter
+from contextlib import AbstractContextManager, ExitStack
+from functools import partial
+from io import StringIO
+from types import CodeType, ModuleType
+from typing import (Any, Optional, Union,
+                    Callable, Generator,
+                    Dict, FrozenSet, Tuple,
+                    ClassVar)
+
+import pytest
+
+from line_profiler import LineProfiler
+from line_profiler._line_profiler import label
+
+
+USE_SYS_MONITORING = isinstance(getattr(sys, 'monitoring', None), ModuleType)
+
+
+# -------------------------------------------------------------------- #
+#                            Helper classes                            #
+# -------------------------------------------------------------------- #
+
+
+class SysMonHelper:
+    """
+    Helper object which helps with simplifying attribute access on
+    :py:mod:`sys.monitoring`.
+    """
+    tool_id: int
+    no_tool_id_callables: ClassVar[FrozenSet[str]] = frozenset(
+        {'restart_events'})
+
+    def __init__(self, tool_id: Optional[int] = None) -> None:
+        if tool_id is None:
+            tool_id = sys.monitoring.PROFILER_ID
+        self.tool_id = tool_id
+
+    def __getattr__(self, attr: str):
+        """
+        Returns:
+            * If ``attr`` refers to a :py:mod:`sys.monitoring` callable:
+              a :py:func:`functools.partial` object with
+              :py:attr:`~.tool_id` pre-applied, unless it is in the set
+              of explicitly excluded methods
+              (:py:attr:`~.no_tool_id_callables`).
+            * If ``attr`` is all uppercase:
+              the corresponding integer or special (e.g.
+              :py:data:`~sys.monitoring.MISSING` and
+              :py:data:`~sys.monitoring.DISABLE`) constants from either
+              the module or the :py:data:`sys.monitoring.events`
+              namespace.
+            * Otherwise, it falls through to the module.
+        """
+        mon = sys.monitoring
+        if attr.isupper():
+            try:
+                return getattr(mon.events, attr)
+            except AttributeError:
+                pass
+        result = getattr(mon, attr)
+        if callable(result) and attr not in self.no_tool_id_callables:
+            return partial(result, self.tool_id)
+        return result
+
+
+class restore_events(AbstractContextManager):
+    """
+    Restore the global or local :py:mod:`sys.monitoring` events.
+    """
+    code: Union[CodeType, None]
+    mon: SysMonHelper
+    events: int
+
+    def __init__(self, *,
+                 code: Optional[CodeType] = None,
+                 tool_id: Optional[int] = None) -> None:
+        self.code = code
+        self.mon = SysMonHelper(tool_id)
+        self.events = sys.monitoring.events.NO_EVENTS
+
+    def __enter__(self):
+        if self.code is None:
+            self.events = self.mon.get_events()
+        else:
+            self.events = self.mon.get_local_events(self.code)
+        return self
+
+    def __exit__(self, *_, **__) -> None:
+        if self.mon.get_tool() is None:
+            pass  # No-op
+        elif self.code is None:
+            self.mon.set_events(self.events)
+        else:
+            self.mon.set_local_events(self.code, self.events)
+        self.events = self.mon.NO_EVENTS
+
+
+class LineCallback:
+    """
+    Simple :py:mod:`sys.monitoring` callback for handling LINE events.
+
+    Attributes:
+        nhits (dict[tuple[str, int, str], Counter[int]])
+            Mapping from
+            :py:attr:`line_profiler._line_profiler.LineStats.timings`
+            keys to a :py:class:`collections.Counter` mapping line
+            numbers to reported hit counts.
+        predicate (Callable[[code, int], bool])
+            Callable taking the code object and line number, and
+            returning whether the line event should be reported.
+        disable (bool)
+            Settable boolean determining whether to return
+            :py:data:`sys.monitoring.DISABLE` on a reported line event.
+    """
+    nhits: Dict[Tuple[str, int, str], 'Counter[int]']
+    predicate: Callable[[CodeType, int], bool]
+    disable: bool
+
+    def __init__(
+        self,
+        predicate: Callable[[CodeType, int], bool],
+        *,
+        register: bool = True,
+        disable: bool = False
+    ) -> None:
+        """
+        Arguments:
+            predicate, disable
+                See attributes.
+            register
+                If true, register the instance with
+                :py:func:`sys.monitoring.register_callback`.
+        """
+        self.nhits = {}
+        self.predicate = predicate
+        self.disable = disable
+        if register:
+            MON.register_callback(MON.LINE, self)
+
+    def __call__(self, code: CodeType, lineno: int) -> Any:
+        """
+        Returns:
+            :py:data:`sys.monitoring.DISABLE` if :py:attr:`~.predicate`
+            evaluates to true AND if :py:attr:`~.disable` is true;
+            :py:const:`None` otherwise.
+
+        Side effects:
+            Entry created/incremented in :py:attr:`~.nhits` if
+            :py:attr:`~.predicate` evaluates to true.
+        """
+        if not self.predicate(code, lineno):
+            return
+        self.nhits.setdefault(label(code), Counter())[lineno] += 1
+        if self.disable:
+            return MON.DISABLE
+
+
+if USE_SYS_MONITORING:
+    MON = SysMonHelper()
+
+
+# -------------------------------------------------------------------- #
+#                           Helper functions                           #
+# -------------------------------------------------------------------- #
+
+
+def enable_line_events(code: Optional[CodeType] = None) -> None:
+    if code is None:
+        MON.set_events(MON.get_events() | MON.LINE)
+    else:
+        MON.set_local_events(code, MON.get_local_events(code) | MON.LINE)
+
+
+def disable_line_events(code: Optional[CodeType] = None) -> None:
+    if code is None:
+        events = MON.get_events()
+        if events & MON.LINE:
+            MON.set_events(events ^ MON.LINE)
+    else:
+        events = MON.get_local_events(code)
+        if events & MON.LINE:
+            MON.set_local_events(code, events | MON.LINE)
+
+
+# -------------------------------------------------------------------- #
+#                                Tests                                 #
+# -------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def sys_mon_cleanup() -> Generator[None, None, None]:
+    """
+    If :py:mod:`sys.monitoring` is available:
+    * Remember all the relevant global callbacks before running the
+      test,
+    * If ``sys.monitoring.PROFILER_ID`` isn't already in use, mark it as
+      being used by `'line_profiler_tests'`, and
+    * Finally, restore these after the test:
+      - The callbacks
+      - The tool name (if we have set it earlier)
+      - The globally-active events (or the lack thereof) for
+        ``sys.monitoring.PROFILER_ID``
+
+    otherwise, automatically :py:func:`pytest.skip` the test.
+    """
+    def restore(message):
+        for name, callback in callbacks.items():
+            prev_callback = MON.register_callback(event_ids[name], callback)
+            if prev_callback is callback:
+                callback_repr = '(UNCHANGED)'
+            else:
+                callback_repr = '-> ' + repr(callback)
+            print('{} (`sys.monitoring.events.{}`): {!r} {}'.format(
+                message, name, prev_callback, callback_repr))
+
+    if not USE_SYS_MONITORING:
+        pytest.skip('No `sys.monitoring`')
+    # Remember the callbacks
+    event_ids = {name: getattr(MON, name)
+                 for name in ('LINE', 'PY_RETURN', 'PY_YIELD')}
+    callbacks = {name: MON.register_callback(event_id, None)
+                 for name, event_id in event_ids.items()}
+    # Restore the callbacks since we "popped" them
+    restore('Pre-test: putting the callbacks back')
+    # Set the tool name if it isn't set already
+    set_tool_id = not MON.get_tool()
+    if set_tool_id:
+        MON.use_tool_id('line_profiler_tests')
+    try:
+        with restore_events():
+            yield
+    finally:
+        # Restore the callbacks
+        restore('Post-test: restoring the callbacks')
+        # Unset the temporary tool name
+        if set_tool_id:
+            MON.free_tool_id()
+
+
+def test_standalone_callback_usage() -> None:
+    """
+    Check that :py:mod:`sys.monitoring` callbacks behave as expected
+    when `LineProfiler`s are not in use.
+    """
+    _test_callback_helper(6, 7, 8, 9)
+
+
+@pytest.mark.parametrize('wrap_trace', [True, False])
+def test_wrapping_trace(wrap_trace: bool) -> None:
+    """
+    Check that existing :py:mod:`sys.monitoring` callbacks behave as
+    expected depending on `LineProfiler.wrap_trace`.
+    """
+    prof = LineProfiler(wrap_trace=wrap_trace)
+    try:
+        nhits_expected = _test_callback_helper(
+            6, 7, 8, 9, prof=prof, wrap=True, callback_called=wrap_trace)
+    finally:
+        with StringIO() as sio:
+            prof.print_stats(sio)
+            output = sio.getvalue()
+        print(output)
+    line = next(line for line in output.splitlines()
+                if line.endswith('# Loop body'))
+    nhits = int(line.split()[1])
+    assert nhits == nhits_expected
+
+
+def _test_callback_helper(
+        nloop_no_trace: int,
+        nloop_trace_global: int,
+        nloop_trace_local: int,
+        nloop_disabled: int,
+        prof: Optional[LineProfiler] = None,
+        wrap: bool = False,
+        callback_called: bool = True) -> int:
+    cumulative_nhits = 0
+
+    def func(n: int) -> int:
+        x = 0
+        for n in range(1, n + 1):
+            x += n  # Loop body
+        return x
+
+    def get_loop_hits() -> int:
+        nonlocal cumulative_nhits
+        cumulative_nhits = callback.nhits[label(code)][lineno_loop]
+        return cumulative_nhits
+
+    lines, first_lineno = inspect.getsourcelines(func)
+    lineno_loop = first_lineno + next(
+        offset for offset, line in enumerate(lines)
+        if line.rstrip().endswith('# Loop body'))
+    names = {func.__name__, func.__qualname__}
+    code = func.__code__
+    if prof is not None:
+        if wrap:
+            orig_func, func = func, prof(func)
+            code = orig_func.__code__
+        else:
+            prof.add_callable(func)
+            code = func.__code__
+    callback = LineCallback(lambda code, _: code.co_name in names)
+
+    # When line events are suppressed, nothing should happen
+    with restore_events():
+        disable_line_events()
+        n = nloop_no_trace
+        assert func(n) == n * (n + 1) // 2
+        assert not callback.nhits
+
+    # When line events are activated, the callback should see line
+    # events
+    with restore_events():  # Global events
+        enable_line_events()
+        n = nloop_trace_global
+        assert func(n) == n * (n + 1) // 2
+        print(callback.nhits)
+        if callback_called:
+            expected = cumulative_nhits + n
+            assert get_loop_hits() == expected
+        else:
+            assert not callback.nhits
+    with ExitStack() as stack:
+        stack.enter_context(restore_events())
+        stack.enter_context(restore_events(code=code))
+        # Disable global line events, and enable local line events
+        disable_line_events()
+        enable_line_events(code)
+        n = nloop_trace_local
+        assert func(n) == n * (n + 1) // 2
+        print(callback.nhits)
+        if callback_called:
+            expected = cumulative_nhits + n
+            assert get_loop_hits() == expected
+        else:
+            assert not callback.nhits
+
+    # Line events can be disabled on the specific line by returning
+    # `sys.monitoring.DISABLE` from the callback
+    for enable_global in True, False:
+        callback.disable = True
+        with ExitStack() as stack:
+            stack.enter_context(restore_events())
+            stack.enter_context(restore_events(code=code))
+            # Set the global and local events
+            # (doesn't matter if events are enabled globally or not)
+            if enable_global:
+                enable_line_events()
+            else:
+                disable_line_events()
+            enable_line_events(code)
+            # We still get 1 more hit because that's the call we
+            # return `sys.monitoring.DISABLE` from
+            n = nloop_disabled
+            assert func(n) == n * (n + 1) // 2
+            print(callback.nhits)
+            if callback_called:
+                expected = cumulative_nhits + 1
+                assert get_loop_hits() == expected
+            else:
+                assert not callback.nhits
+        MON.restart_events()
+
+    # Return the total number of loops run
+    # (Note: `nloop_disabled` is used twice)
+    return (nloop_no_trace
+            + nloop_trace_global
+            + nloop_trace_local
+            + 2 * nloop_disabled)

--- a/tests/test_sys_trace.py
+++ b/tests/test_sys_trace.py
@@ -123,7 +123,11 @@ def isolate_test_in_subproc(
             try:
                 with open(fname, mode='w') as fobj:
                     print(code, file=fobj)
-                proc = subprocess.run(cmd, capture_output=True, text=True)
+                env = os.environ.copy()
+                # Make sure that we're testing the "default behavior"
+                env.pop('LINE_PROFILER_CORE', '')
+                proc = subprocess.run(
+                    cmd, capture_output=True, env=env, text=True)
             finally:
                 os.chdir(curdir)
         if proc.stdout:

--- a/tests/test_sys_trace.py
+++ b/tests/test_sys_trace.py
@@ -631,6 +631,7 @@ def test_python_level_trace_manipulation(
         assert func(n) == expected
     timings = prof.get_stats().timings
     print(timings)
+    prof.print_stats()
     entries = next(entries for (*_, func_name), entries in timings.items()
                    if func_name.endswith(func.__name__))
     body_start_line = min(lineno for (lineno, *_) in entries)

--- a/tests/test_sys_trace.py
+++ b/tests/test_sys_trace.py
@@ -304,6 +304,7 @@ def test_callback_preservation():
     _test_helper_callback_preservation(lambda frame, event, arg: None)
 
 
+@pytest.mark.parametrize('set_frame_local_trace', [True, False])
 @pytest.mark.parametrize(
     ('label', 'use_profiler', 'wrap_trace'),
     [('base case', False, False),
@@ -311,7 +312,8 @@ def test_callback_preservation():
      ('profiled (trace wrapped)', True, True)])
 @isolate_test_in_subproc
 def test_callback_wrapping(
-        label: str, use_profiler: bool, wrap_trace: bool) -> None:
+        label: str, use_profiler: bool,
+        wrap_trace: bool, set_frame_local_trace: bool) -> None:
     """
     Test in a subprocess that the profiler can wrap around an existing
     trace callback such that we both profile the code and do whatever
@@ -322,7 +324,8 @@ def test_callback_wrapping(
     sys.settrace(my_callback)
 
     if use_profiler:
-        profile = LineProfiler(wrap_trace=wrap_trace)
+        profile = LineProfiler(
+            wrap_trace=wrap_trace, set_frame_local_trace=set_frame_local_trace)
         foo_like = profile(foo)
         trace_preserved = wrap_trace
     else:

--- a/tests/test_sys_trace.py
+++ b/tests/test_sys_trace.py
@@ -1,0 +1,519 @@
+"""
+Test the interoperability between `LineProfiler` and other `sys` tracing
+facilities (e.g. Python functions registered via `sys.settrace()`.
+
+Notes
+-----
+- By the very nature of the tests in this test module, they override
+  `sys` trace functions, and are thus largely opaque towards
+  `coverage.py`.
+- However, there effects are isolated since each test is run in a
+  separate Python subprocess.
+"""
+import concurrent.futures
+import functools
+import inspect
+import linecache
+import os
+import subprocess
+import sys
+import time
+import tempfile
+import textwrap
+import threading
+import pytest
+from ast import literal_eval
+from io import StringIO
+from types import FrameType
+from typing import Any, Callable, List, Literal, Union
+from line_profiler import LineProfiler
+
+
+# Common utilities
+
+DEBUG = False
+
+Event = Literal['call', 'line', 'return', 'exception', 'opcode']
+TracingFunc = Callable[[FrameType, Event, Any], Union['TracingFunc', None]]
+
+
+def strip(s: str) -> str:
+    return textwrap.dedent(s).strip('\n')
+
+
+def isolate_test_in_subproc(func: Callable) -> Callable:
+    """
+    Run the test function with the supplied arguments in a subprocess so
+    that it doesn't pollute the state of the current interpretor.
+
+    Notes
+    -----
+    - Code is written to a tempfile and run in a subprocess.
+    - The test function should be import-able from the top-level
+      namespace of this file.
+    - All the arguments should be `ast.literal_eval()`-able.
+    - Beware of using fixtures for these tests.
+    """
+    def message(msg: str, header: str, *,
+                short: bool = False, **kwargs) -> None:
+        header = strip(header)
+        if not header.endswith(':'):
+            header += ':'
+        kwargs['sep'] = '\n'
+        if short and len(msg.splitlines()) < 2:
+            print('', f'{header} {msg}', **kwargs)
+            return
+        print('', header, textwrap.indent(msg, '  '), **kwargs)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Check if the function is importable
+        test_func = func.__name__
+        assert globals()[test_func].__subproc_test_inner__ is func
+
+        # Check if the arguments are round-trippable
+        assert literal_eval(repr(args)) == args
+        assert literal_eval(repr(kwargs)) == kwargs
+
+        # Write a test script
+        args_repr = ', '.join([repr(arg) for arg in args]
+                              + [f'{k}={v!r}' for k, v in kwargs.items()])
+        code_template = strip("""
+        import sys
+        sys.path.insert(0,  # Let the test import from this file
+                        {path!r})
+        from {mod} import (  # Import the test func from this file
+            {test})
+
+        if __name__ == '__main__':
+            {test}.__subproc_test_inner__({args})
+        """)
+        test_dir, test_filename = os.path.split(__file__)
+        test_module_name, dot_py = os.path.splitext(test_filename)
+        assert dot_py == '.py'
+        code = code_template.format(path=test_dir, mod=test_module_name,
+                                    test=test_func, args=args_repr)
+        message(code, 'Test code run')
+
+        # Run the test script in a subprocess
+        with tempfile.TemporaryDirectory() as tmpdir:
+            curdir = os.path.abspath(os.curdir)
+            os.chdir(tmpdir)
+            try:
+                fname = 'my_test.py'
+                with open(fname, mode='w') as fobj:
+                    print(code, file=fobj)
+                proc = subprocess.run([sys.executable, fname],
+                                      capture_output=True, text=True)
+            finally:
+                os.chdir(curdir)
+        if proc.stdout:
+            message(proc.stdout, 'Stdout')
+        else:
+            message('<N/A>', 'Stdout', short=True)
+        if proc.stderr:
+            message(proc.stderr, 'Stderr', file=sys.stderr)
+        else:
+            message('<N/A>', 'Stderr', short=True)
+        proc.check_returncode()
+
+    wrapper.__subproc_test_inner__ = func
+    return wrapper
+
+
+def foo(n: int) -> int:
+    result = 0
+    for spam in range(1, n + 1):
+        result += spam
+    return result
+
+
+def bar(n: int) -> int:
+    result = 0
+    for ham in range(1, n + 1):
+        result += ham
+    return result
+
+
+def baz(n: int) -> int:
+    result = 0
+    for eggs in range(1, n + 1):
+        result += eggs
+    return result
+
+
+def get_incr_logger(logs: List[str], func: Literal[foo, bar, baz] = foo, *,
+                    bugged: bool = False,
+                    report_return: bool = False) -> TracingFunc:
+    '''
+    Append a '<func>: spam = <...>' message whenever we hit the line in
+    `func()` containing the incrementation of `result`.
+    If it's made `bugged`, it sets the frame's `.f_trace_lines` to false
+    after writing the first log entry, disabling line events.
+    If `report_return` is true, a 'Returning from <func>()' log entry
+    is written on return.
+    '''
+    def callback(frame: FrameType, event: Event, _) -> Union[TracingFunc, None]:
+        if DEBUG and callback.emit_debug:
+            print('{0.co_filename}:{1.f_lineno} - {0.co_name} ({2})'
+                  .format(frame.f_code, frame, event))
+        if event == 'call':  # Set up tracing for nested scopes
+            return callback
+        if event not in events:  # Only trace the specified events
+            return
+        code = frame.f_code
+        if code.co_filename != filename or code.co_name != func_name:
+            return
+        if event == 'return':  # Write a return entry where appropriate
+            logs.append(f'Returning from `{func_name}()`')
+            return
+        if frame.f_lineno == lineno:
+            # Add log entry whenever the target line is hit
+            counter_value = frame.f_locals.get(counter)
+            logs.append(f'{func_name}: {counter} = {counter_value}')
+            if bugged:  # Line-event tracing turned off after first hit
+                frame.f_trace_lines = False
+        return callback
+
+    # Get data from `func()`: its (file-)name, the line number of the
+    # incrementation, and the name of the counter variable
+    func_name = func.__name__
+    filename = func.__code__.co_filename
+    lineno = func.__code__.co_firstlineno
+    block = inspect.getblock(linecache.getlines(__file__)[lineno - 1:])
+    (offset, line), = ((i, line) for i, line in enumerate(block)
+                       if 'result +=' in line)
+    lineno += offset
+    counter = line.split()[-1]
+
+    events = {'line'}
+    if report_return:
+        events.add('return')
+
+    callback.emit_debug = False
+    return callback
+
+
+def get_return_logger(logs: List[str], *, bugged: bool = False) -> TracingFunc:
+    '''
+    Append a 'Returning from `<func>()`' message whenever we hit return
+    from a function defined in this file. If it's made `bugged`, it
+    panics and errors out when returning from `bar`, thus unsetting the
+    `sys` trace.
+    '''
+    def callback(frame: FrameType, event: Event, _) -> Union[TracingFunc, None]:
+        if DEBUG and callback.emit_debug:
+            print('{0.co_filename}:{1.f_lineno} - {0.co_name} ({2})'
+                  .format(frame.f_code, frame, event))
+        if event == 'call':
+            # Set up tracing for nested scopes
+            return callback
+        if event != 'return':
+            return  # Only trace return events
+        code = frame.f_code
+        if code.co_filename != __file__:
+            return  # Only trace functions in this file
+        # Add log entry
+        logs.append(f'Returning from `{code.co_name}()`')
+        if bugged and code.co_name == 'bar':
+            # Error out and cause `sys.settrace(None)`
+            raise MyException
+
+    callback.emit_debug = False
+    return callback
+
+
+class MyException(Exception):
+    """Unique exception raised by some of the tests."""
+    pass
+
+
+# Tests
+
+
+def _test_helper_callback_preservation(
+        callback: Union[TracingFunc, None]) -> None:
+    sys.settrace(callback)
+    assert sys.gettrace() is callback, f'can\'t set trace to {callback!r}'
+    profile = LineProfiler(wrap_trace=False)
+    profile.enable_by_count()
+    assert profile in sys.gettrace().active_instances, (
+        'can\'t set trace to the profiler')
+    profile.disable_by_count()
+    assert sys.gettrace() is callback, f'trace not restored to {callback!r}'
+    sys.settrace(None)
+
+
+@isolate_test_in_subproc
+def test_callback_preservation():
+    """
+    Test in a subprocess that the profiler restores the active `sys`
+    trace callback (or the lack thereof) after it's `.disable()`-ed.
+    """
+    _test_helper_callback_preservation(None)
+    _test_helper_callback_preservation(lambda frame, event, arg: None)
+
+
+@pytest.mark.parametrize(
+    ('label', 'use_profiler', 'wrap_trace'),
+    [('base case', False, False),
+     ('profiled (trace suspended)', True, False),
+     ('profiled (trace wrapped)', True, True)])
+@isolate_test_in_subproc
+def test_callback_wrapping(
+        label: str, use_profiler: bool, wrap_trace: bool) -> None:
+    """
+    Test in a subprocess that the profiler can wrap around an existing
+    trace callback such that we both profile the code and do whatever
+    the existing callback does.
+    """
+    logs = []
+    my_callback = get_incr_logger(logs)
+    sys.settrace(my_callback)
+
+    if use_profiler:
+        profile = LineProfiler(wrap_trace=wrap_trace)
+        foo_like = profile(foo)
+        trace_preserved = wrap_trace
+    else:
+        foo_like = foo
+        trace_preserved = True
+    if trace_preserved:
+        exp_logs = [f'foo: spam = {spam}' for spam in range(1, 6)]
+    else:
+        exp_logs = []
+
+    assert sys.gettrace() is my_callback, 'can\'t set custom trace'
+    my_callback.emit_debug = True
+    x = foo_like(5)
+    my_callback.emit_debug = False
+    assert x == 15, f'expected `foo(5) = 15`, got {x!r}'
+    assert sys.gettrace() is my_callback, 'trace not restored afterwards'
+
+    # Check that the existing trace function has been called where
+    # appropriate
+    print(f'Logs: {logs!r}')
+    assert logs == exp_logs, f'expected logs = {exp_logs!r}, got {logs!r}'
+
+    # Check that the profiling is as expected: 5 hits on the
+    # incrementation line
+    if not use_profiler:
+        return
+    with StringIO() as sio:
+        profile.print_stats(stream=sio, summarize=True)
+        out = sio.getvalue()
+    print(out)
+    line, = (line for line in out.splitlines() if '+=' in line)
+    nhits = int(line.split()[1])
+    assert nhits == 5, f'expected 5 profiler hits, got {nhits!r}'
+
+
+@pytest.mark.parametrize(
+    ('label', 'use_profiler', 'enable_count'),
+    [('base case', False, 0),
+     ('profiled (isolated)', True, 0),
+     ('profiled (continuous)', True, 1)])
+@isolate_test_in_subproc
+def test_wrapping_throwing_callback(
+        label: str, use_profiler: bool, enable_count: int) -> None:
+    """
+    Test in a subprocess that if the profiler wraps around an existing
+    trace callback that errors out:
+    - Profiling continues uninterrupted.
+    - The errored-out trace callback is no longer called from the
+      profiling traceback.
+    - The `sys` traceback is set to `None` when the profiler is
+      `.disable()`-ed.
+
+    Notes
+    -----
+    Extra `enable_count` means that the profiler stays enabled between
+    the calls to the profiled functions, and we thereyby test against
+    these problematic behaviors after `my_callback()` bugs out:
+    - If the profiler stops profiling (because the `sys` trace callback
+      is unset), or
+    - If the profiler's callback keeps calling `my_callback()`
+      afterwards.
+    """
+    logs = []
+    my_callback = get_return_logger(logs, bugged=True)
+    sys.settrace(my_callback)
+    assert sys.gettrace() is my_callback, 'can\'t set custom trace'
+
+    if use_profiler:
+        profile = LineProfiler(wrap_trace=True)
+        foo_like, bar_like, baz_like = profile(foo), profile(bar), profile(baz)
+    else:
+        foo_like, bar_like, baz_like = foo, bar, baz
+        enable_count = 0
+
+    for _ in range(enable_count):
+        profile.enable_by_count()
+    my_callback.emit_debug = True
+    x = foo_like(3)  # This is logged
+    try:
+        _ = bar_like(4)  # This is also logged, but...
+    except MyException:
+        # ... the trace func errors out as `bar()` returns, and as such
+        # disables itself
+        pass
+    else:
+        assert False, 'tracing function didn\'t error out'
+    y = baz_like(5)  # Not logged because trace disabled itself
+    my_callback.emit_debug = False
+    for _ in range(enable_count):
+        profile.disable_by_count()
+
+    assert x == 6, f'expected `foo(3) = 6`, got {x!r}'
+    assert y == 15, f'expected `baz(5) = 15`, got {y!r}'
+    assert sys.gettrace() is None, (
+        '`sys` trace = {sys.gettrace()!r} not reset afterwards')
+
+    # Check that the existing trace function has been called where
+    # appropriate
+    print(f'Logs: {logs!r}')
+    exp_logs = ['Returning from `foo()`', 'Returning from `bar()`']
+    assert logs == exp_logs, f'expected logs = {exp_logs!r}, got {logs!r}'
+
+    # Check that the profiling is as expected: 3 (resp. 4, 5) hits on
+    # the incrementation line for `foo()` (resp. `bar()`, `baz()`)
+    if not use_profiler:
+        return
+    with StringIO() as sio:
+        profile.print_stats(stream=sio, summarize=True)
+        out = sio.getvalue()
+    print(out)
+    for func, marker, exp_nhits in [('foo', 'spam', 3), ('bar', 'ham', 4),
+                                    ('baz', 'eggs', 5)]:
+        line, = (line for line in out.splitlines()
+                 if line.endswith('+= ' + marker))
+        nhits = int(line.split()[1])
+        assert nhits == exp_nhits, (f'expected {exp_nhits} '
+                                    f'profiler hits, got {nhits!r}')
+
+
+@pytest.mark.parametrize(('label', 'use_profiler'),
+                         [('base case', False), ('profiled', True)])
+@isolate_test_in_subproc
+def test_wrapping_line_event_disabling_callback(label: str,
+                                                use_profiler: bool) -> None:
+    """
+    Test in a subprocess that if the profiler wraps around an existing
+    trace callback that disables `.f_trace_lines`:
+    - Profiling continues uninterrupted.
+    - `.f_trace` is subsequently disabled, but only for line events in
+      that frame.
+    """
+    logs = []
+    my_callback = get_incr_logger(logs, bugged=True, report_return=True)
+    sys.settrace(my_callback)
+
+    if use_profiler:
+        profile = LineProfiler(wrap_trace=True)
+        foo_like = profile(foo)
+    else:
+        foo_like = foo
+
+    assert sys.gettrace() is my_callback, 'can\'t set custom trace'
+    my_callback.emit_debug = True
+    x = foo_like(5)
+    my_callback.emit_debug = False
+    assert x == 15, f'expected `foo(5) = 15`, got {x!r}'
+    assert sys.gettrace() is my_callback, 'trace not restored afterwards'
+
+    # Check that the trace function has been called exactly once on the
+    # line event, and once on the return event
+    print(f'Logs: {logs!r}')
+    exp_logs = ['foo: spam = 1', 'Returning from `foo()`']
+    assert logs == exp_logs, f'expected logs = {exp_logs!r}, got {logs!r}'
+
+    # Check that the profiling is as expected: 5 hits on the
+    # incrementation line
+    if not use_profiler:
+        return
+    with StringIO() as sio:
+        profile.print_stats(stream=sio, summarize=True)
+        out = sio.getvalue()
+    print(out)
+    line, = (line for line in out.splitlines() if '+=' in line)
+    nhits = int(line.split()[1])
+    assert nhits == 5, f'expected 5 profiler hits, got {nhits!r}'
+
+
+def _test_helper_wrapping_thread_local_callbacks(
+        profile: Union[LineProfiler, None], sleep: float = .0625) -> str:
+    logs = []
+    if threading.current_thread() == threading.main_thread():
+        thread_label = 'main'
+        func = foo
+        my_callback = get_incr_logger(logs, func)
+        exp_logs = [f'foo: spam = {spam}' for spam in range(1, 6)]
+    else:
+        thread_label = 'side'
+        func = bar
+        my_callback = get_return_logger(logs)
+        exp_logs = ['Returning from `bar()`']
+    if profile is None:
+        func_like = func
+    else:
+        func_like = profile(func)
+    print(f'Thread: {threading.get_ident()} ({thread_label})')
+
+    # Check result
+    sys.settrace(my_callback)
+    assert sys.gettrace() is my_callback, 'can\'t set custom trace'
+    my_callback.emit_debug = True
+    x = func_like(5)
+    my_callback.emit_debug = False
+    assert x == 15, f'expected `{func.__name__}(5) = 15`, got {x!r}'
+    assert sys.gettrace() is my_callback, 'trace not restored afterwards'
+
+    # Check logs
+    print(f'Logs ({thread_label} thread): {logs!r}')
+    assert logs == exp_logs, f'expected logs = {exp_logs!r}, got {logs!r}'
+    time.sleep(sleep)
+    return '\n'.join(logs)
+
+
+@pytest.mark.parametrize(('label', 'use_profiler'),
+                         [('base case', False), ('profiled', True)])
+@isolate_test_in_subproc
+def test_wrapping_thread_local_callbacks(label: str,
+                                         use_profiler: bool) -> None:
+    """
+    Test in a subprocess that the profiler properly handles thread-local
+    `sys` trace callbacks.
+    """
+    profile = LineProfiler(wrap_trace=True) if use_profiler else None
+    expected_results = {
+        # From the main thread
+        '\n'.join(f'foo: spam = {spam}' for spam in range(1, 6)),
+        # From the other thread
+        'Returning from `bar()`',
+    }
+
+    # Run tasks (and so some basic checks)
+    results = set()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        tasks = []
+        tasks.append(executor.submit(  # This is run on a side thread
+            _test_helper_wrapping_thread_local_callbacks, profile))
+        # This is run on the main thread
+        results.add(_test_helper_wrapping_thread_local_callbacks(profile))
+        results.update(future.result()
+            for future in concurrent.futures.as_completed(tasks))
+    assert results == expected_results, (f'expected {expected_results!r}, '
+                                         f'got {results!r}')
+
+    # Check profiling
+    if profile is None:
+        return
+    with StringIO() as sio:
+        profile.print_stats(stream=sio, summarize=True)
+        out = sio.getvalue()
+    print(out)
+    for var in 'spam', 'ham':
+        line, = (line for line in out.splitlines()
+                 if line.endswith('+= ' + var))
+        nhits = int(line.split()[1])
+        assert nhits == 5, f'expected 5 profiler hits, got {nhits!r}'


### PR DESCRIPTION
(Closes #333.)

Summary
----

(**Update 12 Jul**: this summary has been completely rewritten to reflect the latest state of affairs)

This draft PR adds C(-ython) level support to:
- Cache the existing trace-callback state(s) when `.enable()`-ing line profiling and restoring said state(s) when `.disable()`-ing it
- Optionally call the cached callback(s) from within the profiler callback(s)
- Improve compatibility with code (e.g. `doctest.DocTestRunner.run()`) using this Python-level paradigm to temporarily alter "legacy" tracing:
  ```python
  callback = sys.gettrace()
  try:
      ...  # Do something which involves swapping/unsetting the trace function
  finally:
      sys.settrace(callback)  # Restore the trace function
  ```

The option to switch back to using the "legacy" system in Python 3.12+ is also added for debugging purposes.

### Code changes

<details>
<summary> (Click to expand) </summary>

- `line_profiler/Python_wrapper.h`  
  New C header wrapping `Python.h`, centralizing backports for the Python C API
- `line_profiler/c_trace_callbacks.{c,h}`  
  New C functions for handling interactions with the trace system:
  - `alloc_callback()`, `free_callback()`, `populate_callback()`, `nullify_callback()`, `restore_callback()`, `call_callback()`  
    Manage the retrieval, use, and restoration of C-level legacy trace callbacks (see `_LineProfilerManager`)
  - `set_local_trace()`  
    Set the frame-local legacy trace function of a frame object to the `_LineProfilerManager`, or attach the manager thereto
  - `monitoring_restart_version()`  
    Get the `.last_restart_version` from the internal interpreter state; this is necessary for detecting calls to `sys.monitoring.restart_events()` 
- `line_profiler/_line_profiler.pyx`
  - `label()`, `_code_replace()`, `LineStats`  
    Updated docstrings
  - `disable_line_events()`  
    New helper function for wrapping a frame-local legacy trace callable so that it no longer receives line events
  - `legacy_trace_callback()`
    - Updated call signature; now expecting a `_LineProfilerManager` (`manager`) instead of a `set[LineProfiler]` (`instances`) as the first argument
    - Now calling the cached legacy trace callback if `manager.wrap_trace` is true
    - Now setting the frame-local legacy trace function if `manager.set_frame_local_trace` is true
  - `_SysMonitoringState`  
    New thread-local (private) helper object for managing the interactions with `sys.monitoring`
    - `enable()`  
      Method to replace and cache the `sys.monitoring` state (relevant callbacks, tool name, active events) upon start of profiling
    - `disable()` 
      Method to restore the cached `sys.monitoring` state upon end of profiling
    - `call_callback()`  
      C-level method to call the cached callbacks in a safe way (i.e. which wouldn't interfere with line profiling) and manage said cache
  - `_LineProfilerManager`  
    New thread-local (private) helper object superseding the set-of-`LineProfiler`s as the object set as the legacy trace-callback object, which retrieves and caches the trace-callback state it replaces when profiling starts and restores them when it ends:
    - With the "legacy" trace system, `PyThreadState.c_tracefunc` and `PyThreadState.c_traceobj` are cached; note that `sys.gettrace()` only gets the latter and misses the former, hence the need for C-level shenanigans
    - With the `sys.monitoring`-based system, the callbacks returned by `sys.monitoring.register_callback()` for the events `sys.monitoring.events.LINE`, `.PY_RETURN`, `.PY_YIELD`, `.RAISE`, and `.RERAISE` are cached

    Class members:
    - `mon_state`  
      `_SysMonitoringState` instance
    - `__call__()`  
      Method providing the same API as Python-level legacy trace functions, so that round-tripping the object (`sys.settrace(sys.gettrace())`) doesn't cause an error
    - `wrap_local_f_trace()`  
      Method for creating wrappers for frame-local legacy trace functions which call both the instance and the wrapped function
    - `handle_line_event()`, `handle_return_event()`, `handle_yield_event()`, `handle_raise_event()`, `handle_reraise_event()`  
      Methods to be supplied to `sys.monitoring.register_callback()` for handling the `sys.monitoring.LINE`, `.PY_RETURN`, `.PY_YIELD`, `.RAISE`, and `.RERAISE` events and optionally calling the corresponding wrapped/cached callbacks; supersede the previous `monitoring_line_event_callback()` and `monitoring_exit_frame_callback()`
      - The cached callbacks and event set are kept updated
      - If a wrapped and cached callback somehow disables tracing (e.g. by trying to unset/change the `sys.monitoring` callbacks with `sys.monitoring.register_callback()`, calling `sys.monitoring.set_events()` to disable line events, or returning `sys.monitoring.DISABLE` to disable events for a certain code location), those changes are isolated so that line profiling is uninterrupted, but said callbacks will no longer receive the relevant event (except when `DISABLE`-d code locations are re-enabled by calling `sys.monitoring.restart_events()`)
    - `_handle_enable_event()`, `_handle_disable_event()`  
      New methods for handling `LineProfiler.enable()` and `.disable()`, managing the interactions with existing states of the tracing/monitoring system
  - `LineProfiler`
    - `__doc__`  
      Extensively extended docstring
    - `tool_id`  
      New class attribute for the `sys.monitoring` tool ID to use
    - `_manager`  
      New thread-local "class attribute" (`_LineProfilerManager` instance) which manages `LineProfiler` instances and provides the trace callbacks, superseding the previous `._active_instances`
    - <a name="line-profiler-wrap_trace">`wrap_trace`</a>  
      New init argument and (thread-local) "class attribute" to control whether existing trace callbacks should be called by the profiling callbacks (true) or stashed away (false)
    - <a name="line-profiler-set_frame_local_trace">`set_frame_local_trace`</a>  
      New init argument and (thread-local) "class attribute" to control whether to set `._manager` as the frame-local legacy trace function, which helps line profiling resume ASAP after legacy tracing is interrupted by e.g. `sys.settrace()`
    - `add_function()`  
      Added caveat warning against direct use; end-users should use `.add_callable()` from the wrapper class `line_profiler.line_profiler.LineProfiler`
    - `enable()`, `disable()`  
      Deferred most of the implementations to `_LineProfilerManager`
- `line_profiler/_diagnostics.py`  
  Added the following environmental switches:
  - `WRAP_TRACE` (env. var.: `${LINE_PROFILER_WRAP_TRACE}`)  
    Boolean flag (default `False`); default value for [`LineProfiler.wrap_trace`](#line-profiler-wrap_trace)
  - `SET_FRAME_LOCAL_TRACE` (env. var.: `${LINE_PROFILER_SET_FRAME_LOCAL_TRACE}`)  
    Boolean flag (default `False`); default value for [`LineProfiler.set_frame_local_trace`](#line-profiler-set_frame_local_trace)
  - `USE_LEGACY_TRACE` (env. var.: `${LINE_PROFILER_CORE}`; `old`, `legacy`, and `ctrace` resolve to `True`; `new`, `sys.monitoring`, and `sysmon` resolve to `False`)  
    Boolean flag (default `False` if `sys.monitoring` is available, `True` otherwise); toggles whether to use the legacy trace system or the new, `sys.monitoring`-based system introduced in #352

</details>

### Test changes

- `tests/test_line_profiler.py::test_sys_monitoring`  
  Updated implementation to always use `sys.monitoring` when available
- `tests/test_sys_monitoring.py`  
  New test module for the `sys.monitoring`-based system
  - `test_standalone_callback_usage()`, `test_wrapping_trace()`  
    Check that simple `sys.monitoring` callbacks behave as expected, and are invoked by `LineProfiler` when `wrap_trace=True`
  - `test_callback_switching()`  
   Checks that `sys.monitoring` callbacks which temper with `sys.monitoring.register_callback()` behave as expected, and are invoked by `LineProfiler` when `wrap_trace=True`
  - `test_callback_update_events()`  
   Checks that `sys.monitoring` callbacks which temper with `sys.monitoring.set_[local_]events()` behave as expected, and are invoked by `LineProfiler` when `wrap_trace=True`
  - `test_callback_toggle_local_events()`  
   Checks that `sys.monitoring` callbacks which return `sys.monitoring.DISABLE` and temper with `sys.monitoring.restart_events()` behave as expected, and are invoked by `LineProfiler` when `wrap_trace=True`
- `tests/test_sys_trace.py`  
  New test module for (mostly) the legacy trace system
  - `test_callback_preservation()`  
    Checks the restoration of the trace-callback state after using the profiler
  - `test_callback_wrapping()`  
    Checks trace-callback interoperability – that the existing trace callback can be used by the profiler's callback; also checks the interoperability of `LineProfiler.wrap_trace` and `LineProfiler.set_frame_local_trace`
  - `test_wrapping_throwing_callback()`  
    Checks the continuation of line profiling and the disabling of the existing callback in the event that it errors out
  - `test_wrapping_line_event_disabling_callback()`  
    Checks the continuation of line profiling and the hiding of line events from the existing frame-local callback in the event that it disables frame line events
  - `test_wrapping_thread_local_callbacks()`  
    Checks the usage and restoration of thread-local existing trace callbacks by the profiler
  - `test_python_level_trace_manipulation()`  
    Checks that line profiling is amenable to the `sys.settrace(sys.gettrace())` paradigm

### Packaging changes

- `docs/`  
  Now including the `.__call__()` methods of objects by default
- `line_profiler/CMakeLists.txt`  
  Updated list of C source files

Motivation
----

As noted in #333, `LineProfiler` currently interacts destructively with `sys.settrace()` and `sys.monitoring.register_callback()`, setting the corresponding trace callbacks to `None` when the profiler is `.disable()`-ed. Beside being in a way "not clean", this also has multiple unfortunate side effects, such as prohibiting cooperative use with other trace-callback based monitoring tools, such as coverage tools and debuggers.

Notably, the discarding of the trace callback was what tanked the coverage that `codecov` reported, because `coverage.py` could't see anything after any test called `LineProfiler.enable()` in-process. While #352 eliminated much of the issues with `codecov`, because `coverage.py` defaults to the legacy trace system while `line_profiler` defaults to `sys.monitoring` where available, it is still desirable for the tool to function correctly (by restoring existing callbacks) and cooperatively (by optionally enabling calling both the line-profiling and existing callbacks) with other tools.

Effects
----

### Python 3.8

| Run on\\Filename | Coverage (%, # lines, # missing) | Test duration/s (best, mean of 3) | Test duration/s (w/coverage) |
| :-: | :-: | :-: | :-: |
| `main` | 70, 1618, 425 | 11.99, 12.03 | 19.76 |
| This PR (as of 224d95d) | 78, 1618, 301 | 11.94, 12.01 | 19.87 |
| This PR w/`LINE_PROFILER_WRAP_TRACE=1` | 79, 1618, 288 | - | 20.25 |

### Python 3.13

| Run on\\Filename | Test duration/s best, mean of 3) | Test duration/s (w/coverage) | Test duration/s (w/coverage, `COVERAGE_CORE=sysmon`) |
| :-: | :-: | :-: | :-: |
| `main` | 14.55, 14.58 | 30.64 | 30.16 |
| This PR (as of 224d95d) | 14.72, 14.82 | 30.85 | 30.10 |
| This PR w/`LINE_PROFILER_WRAP_TRACE=1` | - | 30.89 | 29.97 |

### Notes

- Tests are run with the flag `-k "not test_cython and not test_sys"`, to (1) mitigate Cython-related issues with in some configurations and (2) ensure that the same set of tests is run between the different branches.
- The PR does not change coverage in Python 3.13 because `coverage.py` uses legacy tracing and functions independently of the rest of `sys.monitoring` (which `line_profiler` now uses). Also see comments below ([comment 1](https://github.com/pyutils/line_profiler/pull/334#issuecomment-3062404388), [comment 2](https://github.com/pyutils/line_profiler/pull/334#issuecomment-3065385285)).

Caveats
----

<details>
<summary> (Outdated; click to expand) </summary>

**(UPDATE 17 Apr: the optimizations mentioned below have been made.)**

As shown by the test-suite output above, this PR may introduce some overhead to the tracing function. However:
- The impact on the measured line timings should be minimal, since any interaction with the cached callback is after the collection of timing data.
- A considerable part of the apparent overhead may just have to do with how the cached callback is run more often (i.e. not being outright discarded) after this PR.

Running the entire test suite without `pytest-cov` shows the following results:

| Run on\\Real time elapsed (s; between 10 runs) | Mean | Best | σ |
| :-: | :-: | :-: | :-: |
| `main` | 7.62 | 7.42 | 0.180 |
| This PR | 7.65 | 7.42 | 0.210 |
| This PR w/`LINE_PROFILE_WRAP_TRACE=1` | 7.47 | 7.34 | 0.0983 |

Hence, in the case where we aren't interacting with other tracing facilities, the overhead is negligible and well within normal variations. Still, it may be worth looking into optimizing `wrap_trace` (as implemented in `line_profiler/_line_profiler.pyx::call_c_trace_state_hook_safe()`) since that seem to have more severe performance implications. Since it mostly deals with objects available on the C-level (`CTraceState`, `PyFrameObject.f_trace_lines`, `PyFrameObject.f_trace`), it's likely that  we can eke out more performance by moving `call_c_trace_state_hook_safe()` from Cython to C – or just merge it with the C-level `call_c_trace_state_hook()` function which it calls.

</details>

Update 17 Apr
----

<details>
<summary> (Click to expand) </summary>

### Reorganization

The tests which have to do with `sys` trace callbacks have been moved from the `tests/test_line_profiler.py` module to the new `tests/test_sys_trace.py`.

### Handling of edge cases

In order for trace-callback wrapping to be more transparent (i.e. for the wrapped callback to behave more as if it was free-standing): 
- In normal execution, a trace callback can unset the `sys` callback, either via erroring out or explicitly calling `sys.settrace(None)` (or its C equivalent). If a wrapped callback does so, e.g. in [`coverage.py::coverage/ctracer/tracer.c::CTracer_dealloc()` (L87)](https://github.com/nedbat/coveragepy/blob/287d0f9aedcc72e54d91a84d09e38e87e1b2a43b/coverage/ctracer/tracer.c#L87)):
  - The existing `sys` callback is restored so that profiling continues, as was previously done in this PR; but
  - The profiler's callback drops the cached callback from that point on, effectively disabling the latter; and
  - When the profiler is `.disable()`-ed, it unsets the `sys` trace callback instead of restoring it to the (dropped) cached value.
- In normal execution, a trace callback can set `.f_trace_lines` to false in a frame, disabling line events for the frame (which obstructs further line profiling). If a wrapped callback does so; e.g. in [`coverage.py::coverage/ctracer/tracer.c::CTracer_handle_call()` (L548)](https://github.com/nedbat/coveragepy/blob/287d0f9aedcc72e54d91a84d09e38e87e1b2a43b/coverage/ctracer/tracer.c#L548)):
  - `.f_trace_lines` is reset so that profiling continues, as was previously done in this PR; but
  - The frame's local trace callable `.f_trace` is wrapped so that it is no longer invoked for line events.

Moreover, support for multithreaded environments (where each thread can have its own `sys` trace function) has been added.

### Performance impacts

The previous timing info in "Effects" was unduly biased against the PR in that:
- It was later noted that the virtual environments hosting the `main` and PR branches had different dependency versions (e.g. `pytest`); updating them to be consistent substantially closed the gap.
- Since the new tests temper with the `sys` trace callback, they have to be run in subprocesses to isolate their side effects, resulting in relatively higher overhead.

As such, the venv dependencies have been updated to be consistent (`pytest==8.3.5`, `pytest-cov==6.1.1`, `coverage==7.8.0`), and we now run `run_test.py` or `pytest` with `-k 'not sys_trace'` to deselect the new tests. The updated timings are:

<table>

<tr>
<th>

With `pytest-cov` (`run_tests.py -k 'not sys_trace'`)

</th>
<th>

Without `pytest-cov` (`pytest -k 'not sys_trace'`)

</th>
</tr>

<tr>
<td>

| Run on\\Real time elapsed (s; between 3 runs) | Mean | Best | σ |
| :-: | :-: | :-: | :-: |
| `main` | 15.83 | 15.77 | 0.049 |
| This PR | 15.87 | 15.80 | 0.052 |
| This PR w/`LINE_PROFILE_WRAP_TRACE=1` | 15.83 | 15.80 | 0.033 |

</td>
<td>

| Run on\\Real time elapsed (s; between 10 runs) | Mean | Best | σ |
| :-: | :-: | :-: | :-: |
| `main` | 7.045 | 6.97 | 0.058 |
| This PR | 7.043 | 6.94 | 0.109 |
| This PR w/`LINE_PROFILE_WRAP_TRACE=1` | 7.159 | 7.0 | 0.101 |

</td>
</tr>
</table>

Hence the overhead introduced by the PR seems negligible. (The coverage improvements remain the same as in "Effects" above.)

</details>

Update 19 May
----

<details>
<summary> (Click to expand) </summary>

In response to review, the C-level functions in `line_profiler/_line_profiler.pyx` for handling trace callbacks are refactored out into their own C source/header files `line_profiler/c_trace_callback.c` and `.h`.

To make Python C-API use more consistent (e.g. back-porting of newer utils), the wrapper `line_profiler/Python_wrapper.h` is created around `Python.h`. As such:
- The need to refer to `PY_VERSION_HEX` in C(-ython) code elsewhere is minimized.
- A corner case which pertains to the use of `PyCode_GetCode()` in pre-release versions of Python 3.11 is caught and fixed.

</details>

<a name="section-update-26-may"></a>Update 26 May
----

<details>
<summary> (Click to expand) </summary>

The PR is completely rewritten after #347 was merged due to rebasing difficulties, but most of the previous changes are kept, with the following additions and enhancements:

- `line_profiler/_line_profiler.pyx`:
  - A new object type `_LineProfilerManager` is introduced so that:
    - The trace-callback state is decoupled from individual `LineProfiler` instances.
    - The object returned from `sys.gettrace()` is now:
      - An instance thereof (instead of being a `set[LineProfiler]`)
      - Callable as a Python-level trace function which returns itself, and
      - Amenable to being set via `sys.settrace()`;

     This improves compatibility when profiling code which does something like the below example (e.g. [`doctest.DocTestRunner.run()`](https://github.com/python/cpython/blob/e483dcf19eee7143ba76d1829afc1052053a904e/Lib/doctest.py#L1565)):
      ```python
      callback = sys.gettrace()  # This returns the manager object
      try:
          sys.settrace(something_else)  # This suspends line profiling
          ...
      finally:
          # This restores the manager object and resumes profiling,
          # but causes problems if it isn't callable w/the signature
          # `(frame: types.FrameType,
          #   event: Literal['call', 'line', 'return', 'exception', 'opcode'],
          #   arg: object)`
          sys.settrace(callback)
      ```
    The overhead should be minimal since the `.__call__()` resets the C-level trace callback to `python_trace_callback()` where possible, sidestepping `.__call__()` and the [default `sys` trace trampoline](https://github.com/python/cpython/blob/cf8941c60356acdd00055e5583a2d64761c34af4/Python/sysmodule.c#L1101) which calls it indirectly.
  - `LineProfiler.wrap_trace` is now a pseudo class attribute and synced between all instances.
  - `LineProfiler` now takes an extra `set_frame_local_trace` argument (taking its default from the `${LINE_PROFILE_WRAP_TRACE}`) environment variable), which optionally sets the frame-local trace function `types.FrameType.f_trace` to the manager upon `PyTrace_CALL` events, facilitating the resumption of line profiling after suspension as in the above code example.
- `tests/test_sys_trace.py::test_python_level_trace_manipulation()`:  
  New test checking that line profiling plays well with Python-level code which uses `sys.gettrace()` and `sys.settrace()` to manipulate the trace-callback state.

</details>

<a name="section-update-11-jul"></a>Update 11 Jul
----

<details>
<summary> (Click to expand) </summary>

Since #352 we've been moving towards using `sys.monitoring` where available (Python 3.12+), instead of the legacy trace system (`sys.gettrace()`, `sys.settrace()`, `PyEval_SetTrace()`). The PR is thus updated so that `LineProfiler`s can cache and wrap `sys.monitoring` callbacks, like it does with legacy trace callbacks:

- `line_profiler/_line_profiler.pyx`:
  - `_LineProfilerManager`:
    - Added new helper object `.mon_state = _SysMonitoringState` for managing interfacing with `sys.monitoring`
    - Added new methods `handle_{line,return,yield}_event()` to be used with `sys.monitoring.register_callback(sys.monitoring.PROFILER_ID, sys.monitoring.{LINE,PY_RETURN,PY_YIELD}, ...)`
  - `_SysMonitoringState`:  
    New helper object to store and restore the `sys.monitoring` state, as well as to handle cached callbacks
- `tests/test_sys_monitoring.py`:  
  New test module for `sys.monitoring`-related tests
  - `test_standalone_callback_usage()`, `test_standalone_callback_switching()`:  
    New tests verifying basic behaviors of `sys.monitoring` callbacks
  - `test_wrapping_trace()`, `test_wrapping_switching_callback()`:  
    New tests checking `LineProfiler` interacts with existing `sys.monitoring` callbacks as expected

</details>