### PR TITLE
ENH: auto-profile `stdin` or literal snippets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changes
 * FIX: Fixed explicit profiling of class methods; added handling for profiling static, bound, and partial methods, ``functools.partial`` objects, (cached) properties, and async generator functions
 * FIX: Fixed namespace bug when running ``kernprof -m`` on certain modules (e.g. ``calendar`` on Python 3.12+).
 * FIX: Fixed ``@contextlib.contextmanager`` bug where the cleanup code (e.g. restoration of ``sys`` attributes) is not run if exceptions occurred inside the context
+* ENH: Added CLI arguments ``-c`` to ``kernprof`` for (auto-)profiling module/package/inline-script execution instead of that of script files; passing ``'-'`` as the script-file name now also reads from and profiles ``stdin``
 
 4.2.0
 ~~~~~

--- a/docs/source/manual/examples/example_kernprof.rst
+++ b/docs/source/manual/examples/example_kernprof.rst
@@ -6,8 +6,7 @@ and profile Python code in various forms.
 
 For the following, we assume that we have:
 
-* the below file ``fib.py`` in the current directory,
-* the current directory in ``${PYTHONPATH}``, and
+* the below file ``fib.py`` in the current directory, and
 * :py:mod:`line_profiler` and :py:mod:`kernprof` installed.
 
 .. code:: python
@@ -62,10 +61,18 @@ Script execution
 In the most basic form, one passes the path to the executed script and
 its arguments to ``kernprof``:
 
-.. code:: console
+.. code:: bash
 
-    $ kernprof --prof-mod fib.py --line-by-line --view \
-    > fib.py --verbose 10 20 30
+    kernprof --prof-mod fib.py --line-by-line --view \
+        fib.py --verbose 10 20 30
+
+.. raw:: html
+
+    <details>
+    <summary>Output (click to expand)</summary>
+
+.. code::
+
     fib(10) = 89
     fib(20) = 10946
     fib(30) = 1346269
@@ -126,6 +133,12 @@ its arguments to ``kernprof``:
         37         3         91.0     30.3     18.7          result = func(n)
         38         3         20.0      6.7      4.1          print(pattern.format(n, result))
 
+.. raw:: html
+
+    </details>
+    <p>
+
+
 .. _kernprof-script-note:
 .. note::
 
@@ -141,15 +154,29 @@ Module execution
 It is also possible to use ``kernprof -m`` to run installed modules and
 packages:
 
-.. code:: console
+.. code:: bash
 
-    $ kernprof --prof-mod fib --line-by-line --view -m \
-    > fib --verbose 10 20 30
+    PYTHONPATH="${PYTHONPATH}:${PWD}" \
+        kernprof --prof-mod fib --line-by-line --view -m \
+        fib --verbose 10 20 30
+
+.. raw:: html
+
+    <details>
+    <summary>Output (click to expand)</summary>
+
+.. code::
+
     fib(10) = 89
     fib(20) = 10946
     fib(30) = 1346269
     Wrote profile results to fib.lprof
     ...
+
+.. raw:: html
+
+    </details>
+    <p>
 
 .. _kernprof-m-note:
 .. note::
@@ -159,12 +186,24 @@ packages:
     thereafter (the run module).
     If there isn't one, an error is raised:
 
-    .. code:: console
+    .. code:: bash
 
-        $ kernprof -m
+        kernprof -m
+
+    .. raw:: html
+
+        <details>
+        <summary>Output (click to expand)</summary>
+
+    .. code:: pycon
+
         Traceback (most recent call last):
           ...
         ValueError: argument expected for the -m option
+
+    .. raw:: html
+
+        </details>
 
 
 Literal-code execution
@@ -174,12 +213,23 @@ Like how ``kernprof -m`` parallels ``python -m``, ``kernprof -c`` can be
 used to run and profile literal snippets supplied on the command line
 like ``python -c``:
 
-.. code:: console
+.. code:: bash
 
-    $ code="import sys; "
-    $ code+="from fib import _run_fib, fib_no_cache as fib; "
-    $ code+="for n in sys.argv[1:]: print(f'fib({n})', '=', fib(int(n)))"
-    $ kernprof --prof-mod fib._run_fib --line-by-line --view -c "${code}" 10 20
+    PYTHONPATH="${PYTHONPATH}:${PWD}" \
+        kernprof --prof-mod fib._run_fib --line-by-line --view -c "
+        import sys
+        from fib import _run_fib, fib_no_cache as fib
+        for n in sys.argv[1:]:
+            print(f'fib({n})', '=', fib(int(n)))
+        " 10 20
+
+.. raw:: html
+
+    <details>
+    <summary>Output (click to expand)</summary>
+
+.. code::
+
     fib(10) = 89
     fib(20) = 10946
     Wrote profile results to <...>/kernprof-command-imuhz89_.lprof
@@ -200,6 +250,11 @@ like ``python -c``:
         22     11033       1477.0      0.1     18.4      prev = fib(n - 1)
         23     11033        770.0      0.1      9.6      return prev_prev + prev
 
+.. raw:: html
+
+    </details>
+    <p>
+
 .. note::
 
     * As with ``python -c``, the ``-c`` option terminates further
@@ -215,18 +270,25 @@ like ``python -c``:
       ``python -m line_profiler`` and has to be ``--view``-ed
       immediately:
 
-      .. code:: console
+      .. code:: bash
 
-          $ read -d '' -r code <<-'!'
-          > from fib import fib
-          >
-          > def my_func(n=50):
-          >     result = fib(n)
-          >     print(n, '->', result)
-          >
-          > my_func()
-          > !
-          $ kernprof -lv -c "${code}"
+          PYTHONPATH="${PYTHONPATH}:${PWD}" \
+              kernprof --line-by-line --view -c "
+              from fib import fib
+
+              def my_func(n=50):
+                  result = fib(n)
+                  print(n, '->', result)
+
+              my_func()"
+
+      .. raw:: html
+
+          <details>
+          <summary>Output (click to expand)</summary>
+
+      .. code::
+
           50 -> 20365011074
           Wrote profile results to <...>/kernprof-command-ni6nis6t.lprof
           Timer unit: 1e-06 s
@@ -241,7 +303,22 @@ like ``python -c``:
                4         1         26.0     26.0     68.4      result = fib(n)
                5         1         12.0     12.0     31.6      print(n, '->', result)
 
-          $ python -m line_profiler kernprof-command-ni6nis6t.lprof 
+      .. raw:: html
+
+          </details>
+          <p>
+
+      .. code:: bash
+
+          python -m line_profiler kernprof-command-ni6nis6t.lprof
+
+      .. raw:: html
+
+          <details>
+          <summary>Output (click to expand)</summary>
+
+      .. code::
+
           Timer unit: 1e-06 s
           
           Total time: 3.6e-05 s
@@ -257,6 +334,10 @@ like ``python -c``:
                4         1         26.0     26.0     72.2  
                5         1         10.0     10.0     27.8  
 
+      .. raw:: html
+
+          </details>
+
 
 Executing code read from ``stdin``
 ----------------------------------
@@ -264,18 +345,34 @@ Executing code read from ``stdin``
 It is also possible to read, run, and profile code from ``stdin``, by
 passing ``-`` to ``kernprof`` in place of a filename:
 
-.. code:: console
+.. code:: bash
 
-    $ kernprof --prof-mod fib._run_fib --line-by-line --view - 10 20 <<-'!'
-    > import sys
-    > from fib import _run_fib, fib_no_cache as fib
-    > for n in sys.argv[1:]:
-    >     print(f"fib({n})", "=", fib(int(n)))
-    > !
+    {
+        # This example doesn't make much sense on its own, but just
+        # imagine if this is a command generating code dynamically
+        echo 'import sys'
+        echo 'from fib import _run_fib, fib_no_cache as fib'
+        echo 'for n in sys.argv[1:]:'
+        echo '    print(f"fib({n})", "=", fib(int(n)))'
+    } | PYTHONPATH="${PYTHONPATH}:${PWD}" \
+        kernprof --prof-mod fib._run_fib --line-by-line --view - 10 20
+
+.. raw:: html
+
+    <details>
+    <summary>Output (click to expand)</summary>
+
+.. code::
+
     fib(10) = 89
     fib(20) = 10946
     Wrote profile results to <...>/kernprof-stdin-kntk2lo1.lprof
     ...
+
+.. raw:: html
+
+    </details>
+    <p>
 
 .. note::
 

--- a/docs/source/manual/examples/example_kernprof.rst
+++ b/docs/source/manual/examples/example_kernprof.rst
@@ -1,0 +1,286 @@
+``kernprof`` invocations
+========================
+
+The module (and installed script) :py:mod:`kernprof` can be used to run
+and profile Python code in various forms.
+
+For the following, we assume that we have:
+
+* the below file ``fib.py`` in the current directory,
+* the current directory in ``${PYTHONPATH}``, and
+* :py:mod:`line_profiler` and :py:mod:`kernprof` installed.
+
+.. code:: python
+
+    import functools
+    import sys
+    from argparse import ArgumentParser
+    from typing import Callable, Optional, Sequence
+
+
+    @functools.lru_cache()
+    def fib(n: int) -> int:
+        return _run_fib(fib, n)
+
+
+    def fib_no_cache(n: int) -> int:
+        return _run_fib(fib_no_cache, n)
+
+
+    def _run_fib(fib: Callable[[int], int], n: int) -> int:
+        if n < 0:
+            raise ValueError(f'{n = !r}: expected non-negative integer')
+        if n < 2:
+            return 1
+        prev_prev = fib(n - 2)
+        prev = fib(n - 1)
+        return prev_prev + prev
+
+
+    def main(args: Optional[Sequence[str]] = None) -> None:
+        parser = ArgumentParser()
+        parser.add_argument('n', nargs='+', type=int)
+        parser.add_argument('--verbose', action='store_true')
+        parser.add_argument('--no-cache', action='store_true')
+        arguments = parser.parse_args(args)
+
+        pattern = 'fib({!r}) = {!r}' if arguments.verbose else '{1!r}'
+        func = fib_no_cache if arguments.no_cache else fib
+
+        for n in arguments.n:
+            result = func(n)
+            print(pattern.format(n, result))
+
+
+    if __name__ == '__main__':
+        main()
+
+
+Script execution
+----------------
+
+In the most basic form, one passes the path to the executed script and
+its arguments to ``kernprof``:
+
+.. code:: console
+
+    $ kernprof --prof-mod fib.py --line-by-line --view \
+    > fib.py --verbose 10 20 30
+    fib(10) = 89
+    fib(20) = 10946
+    fib(30) = 1346269
+    Wrote profile results to fib.py.lprof
+    Timer unit: 1e-06 s
+
+    Total time: 5.6e-05 s
+    File: fib.py
+    Function: fib at line 7
+
+    Line #      Hits         Time  Per Hit   % Time  Line Contents
+    ==============================================================
+         7                                           @functools.lru_cache()
+         8                                           def fib(n: int) -> int:
+         9        31         56.0      1.8    100.0      return _run_fib(fib, n)
+
+    Total time: 0 s
+    File: fib.py
+    Function: fib_no_cache at line 12
+
+    Line #      Hits         Time  Per Hit   % Time  Line Contents
+    ==============================================================
+        12                                           def fib_no_cache(n: int) -> int:
+        13                                               return _run_fib(fib_no_cache, n)
+
+    Total time: 3.8e-05 s
+    File: fib.py
+    Function: _run_fib at line 16
+
+    Line #      Hits         Time  Per Hit   % Time  Line Contents
+    ==============================================================
+        16                                           def _run_fib(fib: Callable[[int], int], n: int) -> int:
+        17        31          3.0      0.1      7.9      if n < 0:
+        18                                                   raise ValueError(f'{n = !r}: expected non-negative integer')
+        19        31          2.0      0.1      5.3      if n < 2:
+        20         2          0.0      0.0      0.0          return 1
+        21        29         18.0      0.6     47.4      prev_prev = fib(n - 2)
+        22        29         12.0      0.4     31.6      prev = fib(n - 1)
+        23        29          3.0      0.1      7.9      return prev_prev + prev
+
+    Total time: 0.000486 s
+    File: fib.py
+    Function: main at line 26
+
+    Line #      Hits         Time  Per Hit   % Time  Line Contents
+    ==============================================================
+        26                                           def main(args: Optional[Sequence[str]] = None) -> None:
+        27         1        184.0    184.0     37.9      parser = ArgumentParser()
+        28         1         17.0     17.0      3.5      parser.add_argument('n', nargs='+', type=int)
+        29         1         16.0     16.0      3.3      parser.add_argument('--verbose', action='store_true')
+        30         1         14.0     14.0      2.9      parser.add_argument('--no-cache', action='store_true')
+        31         1        144.0    144.0     29.6      arguments = parser.parse_args(args)
+        32                                           
+        33         1          0.0      0.0      0.0      pattern = 'fib({!r}) = {!r}' if arguments.verbose else '{1!r}'
+        34         1          0.0      0.0      0.0      func = fib_no_cache if arguments.no_cache else fib
+        35                                           
+        36         4          0.0      0.0      0.0      for n in arguments.n:
+        37         3         91.0     30.3     18.7          result = func(n)
+        38         3         20.0      6.7      4.1          print(pattern.format(n, result))
+
+.. _kernprof-script-note:
+.. note::
+
+   Instead of passing the ``--view`` flag to ``kernprof`` to view the
+   profiling results immediately, sometimes it can be more convenient to
+   just generate the profiling results and view them later by running
+   the :py:mod:`line_profiler` module (``python -m line_profiler``).
+
+
+Module execution
+----------------
+
+It is also possible to use ``kernprof -m`` to run installed modules and
+packages:
+
+.. code:: console
+
+    $ kernprof --prof-mod fib --line-by-line --view -m \
+    > fib --verbose 10 20 30
+    fib(10) = 89
+    fib(20) = 10946
+    fib(30) = 1346269
+    Wrote profile results to fib.lprof
+    ...
+
+.. _kernprof-m-note:
+.. note::
+
+    As with ``python -m``, the ``-m`` option terminates further parsing
+    of arguments by ``kernprof`` and passes them all to the argument
+    thereafter (the run module).
+    If there isn't one, an error is raised:
+
+    .. code:: console
+
+        $ kernprof -m
+        Traceback (most recent call last):
+          ...
+        ValueError: argument expected for the -m option
+
+
+Literal-code execution
+----------------------
+
+Like how ``kernprof -m`` parallels ``python -m``, ``kernprof -c`` can be
+used to run and profile literal snippets supplied on the command line
+like ``python -c``:
+
+.. code:: console
+
+    $ code="import sys; "
+    $ code+="from fib import _run_fib, fib_no_cache as fib; "
+    $ code+="for n in sys.argv[1:]: print(f'fib({n})', '=', fib(int(n)))"
+    $ kernprof --prof-mod fib._run_fib --line-by-line --view -c "${code}" 10 20
+    fib(10) = 89
+    fib(20) = 10946
+    Wrote profile results to <...>/kernprof-command-imuhz89_.lprof
+    Timer unit: 1e-06 s
+
+    Total time: 0.007666 s
+    File: <...>/fib.py
+    Function: _run_fib at line 16
+
+    Line #      Hits         Time  Per Hit   % Time  Line Contents
+    ==============================================================
+        16                                           def _run_fib(fib: Callable[[int], int], n: int) -> int:
+        17     22068       1656.0      0.1     20.6      if n < 0:
+        18                                                   raise ValueError(f'{n = !r}: expected non-negative integer')
+        19     22068       1663.0      0.1     20.7      if n < 2:
+        20     11035        814.0      0.1     10.1          return 1
+        21     11033       1668.0      0.2     20.7      prev_prev = fib(n - 2)
+        22     11033       1477.0      0.1     18.4      prev = fib(n - 1)
+        23     11033        770.0      0.1      9.6      return prev_prev + prev
+
+.. note::
+
+    * As with ``python -c``, the ``-c`` option terminates further
+      parsing of arguments by ``kernprof`` and passes them all to the
+      argument thereafter (the executed code).
+      If there isn't one, an error is raised as
+      :ref:`above <kernprof-m-note>` with ``kernprof -m``.
+    * .. _kernprof-c-note:
+      Since the temporary file containing the executed code will not
+      exist beyond the ``kernprof`` process, profiling results
+      pertaining to targets (function definitions) local to said code
+      :ref:`will not be accessible later <kernprof-script-note>` by
+      ``python -m line_profiler`` and has to be ``--view``-ed
+      immediately:
+
+      .. code:: console
+
+          $ read -d '' -r code <<-'!'
+          > from fib import fib
+          >
+          > def my_func(n=50):
+          >     result = fib(n)
+          >     print(n, '->', result)
+          >
+          > my_func()
+          > !
+          $ kernprof -lv -c "${code}"
+          50 -> 20365011074
+          Wrote profile results to <...>/kernprof-command-ni6nis6t.lprof
+          Timer unit: 1e-06 s
+
+          Total time: 3.8e-05 s
+          File: <...>/kernprof-command.py
+          Function: my_func at line 3
+
+          Line #      Hits         Time  Per Hit   % Time  Line Contents
+          ==============================================================
+               3                                           def my_func(n=50):
+               4         1         26.0     26.0     68.4      result = fib(n)
+               5         1         12.0     12.0     31.6      print(n, '->', result)
+
+          $ python -m line_profiler kernprof-command-ni6nis6t.lprof 
+          Timer unit: 1e-06 s
+          
+          Total time: 3.6e-05 s
+          
+          Could not find file <...>/kernprof-command.py
+          Are you sure you are running this program from the same directory
+          that you ran the profiler from?
+          Continuing without the function's contents.
+
+          Line #      Hits         Time  Per Hit   % Time  Line Contents
+          ==============================================================
+               3                                           
+               4         1         26.0     26.0     72.2  
+               5         1         10.0     10.0     27.8  
+
+
+Executing code read from ``stdin``
+----------------------------------
+
+It is also possible to read, run, and profile code from ``stdin``, by
+passing ``-`` to ``kernprof`` in place of a filename:
+
+.. code:: console
+
+    $ kernprof --prof-mod fib._run_fib --line-by-line --view - 10 20 <<-'!'
+    > import sys
+    > from fib import _run_fib, fib_no_cache as fib
+    > for n in sys.argv[1:]:
+    >     print(f"fib({n})", "=", fib(int(n)))
+    > !
+    fib(10) = 89
+    fib(20) = 10946
+    Wrote profile results to <...>/kernprof-stdin-kntk2lo1.lprof
+    ...
+
+.. note::
+
+    Since the temporary file containing the executed code will not exist
+    beyond the ``kernprof`` process, profiling results pertaining to
+    targets (function definitions) local to said code will not be
+    accessible later and has to be ``--view``-ed immediately
+    (see :ref:`above note <kernprof-c-note>` on ``kernprof -c``).

--- a/docs/source/manual/examples/index.rst
+++ b/docs/source/manual/examples/index.rst
@@ -5,6 +5,8 @@ Examples of line profiler usage:
 
 + `Basic Usage <../../index.html#line-profiler-basic-usage>`_
 
++ `kernprof invocations <example_kernprof.rst>`_
+
 + `Auto Profiling <../../auto/line_profiler.autoprofile.html#auto-profiling>`_
 
 + `Explicit Profiler <../../auto/line_profiler.explicit_profiler.html#module-line_profiler.explicit_profiler>`_

--- a/kernprof.py
+++ b/kernprof.py
@@ -50,6 +50,8 @@ NOTE:
     * ``kernprof <options> - <args to code>`` parallels ``python -`` and
       executes literal code passed via the ``stdin``.
 
+    See also :doc:`kernprof invocations </manual/examples/example_kernprof>`.
+
 For more details and options, refer to the CLI help.
 To view kernprof help run:
 

--- a/kernprof.py
+++ b/kernprof.py
@@ -51,12 +51,14 @@ which displays:
 
 .. code::
 
-    usage: kernprof [-h] [-V] [-l] [-b] [-o OUTFILE] [-s SETUP] [-v] [-r] [-u UNIT] [-z] [-i [OUTPUT_INTERVAL]] [-p PROF_MOD] [-m] [--prof-imports] {script | -m module} ...
+    usage: kernprof [-h] [-V] [-l] [-b] [-o OUTFILE] [-s SETUP] [-v] [-r] [-u UNIT] [-z] [-i [OUTPUT_INTERVAL]] [-p PROF_MOD] [--prof-imports]
+                    {path/to/script | -m path.to.module | -c "literal code"} ...
 
     Run and profile a python script.
 
     positional arguments:
-      {script | -m module}  The python script file or module to run
+      {path/to/script | -m path.to.module | -c "literal code"}
+                            The python script file, module, or literal code to run
       args                  Optional script arguments
 
     options:
@@ -64,16 +66,16 @@ which displays:
       -V, --version         show program's version number and exit
       -l, --line-by-line    Use the line-by-line profiler instead of cProfile. Implies --builtin.
       -b, --builtin         Put 'profile' in the builtins. Use 'profile.enable()'/'.disable()', '@profile' to decorate functions, or 'with profile:' to profile a section of code.
-      -o OUTFILE, --outfile OUTFILE
+      -o, --outfile OUTFILE
                             Save stats to <outfile> (default: 'scriptname.lprof' with --line-by-line, 'scriptname.prof' without)
-      -s SETUP, --setup SETUP
-                            Code to execute before the code to profile
+      -s, --setup SETUP     Code to execute before the code to profile
       -v, --view            View the results of the profile in addition to saving it
       -r, --rich            Use rich formatting if viewing output
-      -u UNIT, --unit UNIT  Output unit (in seconds) in which the timing info is displayed (default: 1e-6)
+      -u, --unit UNIT       Output unit (in seconds) in which the timing info is displayed (default: 1e-6)
       -z, --skip-zero       Hide functions which have not been called
-      -i [OUTPUT_INTERVAL], --output-interval [OUTPUT_INTERVAL]
-                            Enables outputting of cumulative profiling results to file every n seconds. Uses the threading module. Minimum value is 1 (second). Defaults to disabled.
+      -i, --output-interval [OUTPUT_INTERVAL]
+                            Enables outputting of cumulative profiling results to file every n seconds. Uses the threading module. Minimum value is 1 (second). Defaults to
+                            disabled.
       -p, --prof-mod PROF_MOD
                             List of modules, functions and/or classes to profile specified by their name or path. List is comma separated, adding the current script path profiles
                             the full script. Multiple copies of this flag can be supplied and the.list is extended. Only works with line_profiler -l, --line-by-line
@@ -215,12 +217,10 @@ def _python_command():
     Return a command that corresponds to :py:obj:`sys.executable`.
     """
     import shutil
-    if shutil.which('python') == sys.executable:
-        return 'python'
-    elif shutil.which('python3') == sys.executable:
-        return 'python3'
-    else:
-        return sys.executable
+    for abbr in 'python', 'python3':
+        if os.path.samefile(shutil.which(abbr), sys.executable):
+            return abbr
+    return sys.executable
 
 
 class _restore_list:
@@ -345,11 +345,22 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
 
-    # Special case: `kernprof [...] -m <module>` should terminate the
-    # parsing of all subsequent options
-    args, module, post_args = pre_parse_single_arg_directive(args, '-m')
+    # Special cases: `kernprof [...] -m <module>` or
+    # `kernprof [...] -c <script>` should terminate the parsing of all
+    # subsequent options
+    if '-m' in args and '-c' in args:
+        special_mode = min(['-c', '-m'], key=args.index)
+    elif '-m' in args:
+        special_mode = '-m'
+    else:
+        special_mode = '-c'
+    args, thing, post_args = pre_parse_single_arg_directive(args, special_mode)
+    if special_mode == '-m':
+        module, literal_code = thing, None
+    else:
+        module, literal_code = None, thing
 
-    if module is None:  # Normal execution
+    if module is literal_code is None:  # Normal execution
         real_parser, = parsers = [create_parser()]
         help_parser = None
     else:
@@ -396,10 +407,12 @@ def main(args=None):
                             help="If specified, modules specified to `--prof-mod` will also autoprofile modules that they import. "
                             "Only works with line_profiler -l, --line-by-line")
 
-        if parser is help_parser or module is None:
+        if parser is help_parser or module is literal_code is None:
             parser.add_argument('script',
-                                metavar='{script | -m module}',
-                                help='The python script file or module to run')
+                                metavar='{path/to/script'
+                                ' | -m path.to.module | -c "literal code"}',
+                                help='The python script file, module, or '
+                                'literal code to run')
         parser.add_argument('args', nargs='...', help='Optional script arguments')
 
     # Hand off to the dummy parser if necessary to generate the help
@@ -407,16 +420,65 @@ def main(args=None):
     options = real_parser.parse_args(args)
     if help_parser and getattr(options, 'help', False):
         # This should raise a `SystemExit`
-        help_parser.parse_args([*args, '-m', module])
+        help_parser.parse_args([*args, '-m', 'dummy'])
     try:
         del options.help
     except AttributeError:
         pass
-    # Add in the pre-partitioned arguments cut off by `-m <module>`
+    # Add in the pre-partitioned arguments cut off by `-m <module>` or
+    # `-c <script>`
     options.args += post_args
     if module is not None:
         options.script = module
 
+    tempfile_source_and_content = None
+    if literal_code is not None:
+        tempfile_source_and_content = 'command', literal_code
+    elif options.script == '-' and not module:
+        tempfile_source_and_content = 'stdin', sys.stdin.read()
+
+    if not tempfile_source_and_content:
+        return _main(options, module)
+
+    # Importing `ast` is IIRC somewhat expensive, so don't do that if we
+    # don't have to
+    import ast
+    import tempfile
+
+    source, content = tempfile_source_and_content
+    file_prefix = f'kernprof-{source}-'
+    with tempfile.NamedTemporaryFile(mode='w',
+                                     prefix=file_prefix,
+                                     suffix='.py') as fobj:
+        # Set up the script to be run
+        try:
+            content = ast.unparse(ast.parse(content))
+        except (
+                # `ast.unparse()` unavailable in Python < 3.9
+                AttributeError,
+                # Big module - shouldn't happen since the script should
+                # just be one inline thing (except when reading from
+                # stdin), which can't be all that complicated
+                RecursionError):
+            pass
+        print(content, file=fobj, flush=True)
+        options.script = fobj.name
+        # Add the tempfile to `--prof-mod`
+        if options.prof_mod:
+            options.prof_mod += ',' + fobj.name
+        else:
+            options.prof_mod = fobj.name
+        # Set the output file to somewhere nicer (also take care of
+        # possible filename clash)
+        if not options.outfile:
+            extension = 'lprof' if options.line_by_line else 'prof'
+            _, options.outfile = tempfile.mkstemp(dir=os.curdir,
+                                                  prefix=file_prefix,
+                                                  suffix='.' + extension)
+        return _main(options, module)
+
+
+def _main(options, module=False):
     if not options.outfile:
         extension = 'lprof' if options.line_by_line else 'prof'
         options.outfile = '%s.%s' % (os.path.basename(options.script), extension)

--- a/kernprof.py
+++ b/kernprof.py
@@ -89,6 +89,7 @@ import threading
 import asyncio  # NOQA
 import concurrent.futures  # NOQA
 import time
+import warnings
 from argparse import ArgumentError, ArgumentParser
 from runpy import run_module
 
@@ -457,8 +458,10 @@ def main(args=None):
                 # Big module - shouldn't happen since the script should
                 # just be one inline thing (except when reading from
                 # stdin), which can't be all that complicated
-                RecursionError):
-            pass
+                RecursionError) as e:
+            msg = (f'cannot pretty-print code read from {source} ({e!r}), '
+                   'writing it to a temporary file as-is')
+            warnings.warn(msg)
         fname = os.path.join(tmpdir, file_prefix + '.py')
         with open(fname, mode='w') as fobj:
             print(content, file=fobj)

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -529,28 +529,31 @@ def test_autoprofile_exec_module(
     assert ('Function: _main' in raw_output) == main
 
 
+@pytest.mark.parametrize('view', [True, False])
+@pytest.mark.parametrize('prof_mod', [True, False])
 @pytest.mark.parametrize(
     ('outfile', 'expected_outfile'),
     [(None, 'kernprof-stdin-*.lprof'),
      ('test-stdin.lprof', 'test-stdin.lprof')])
 def test_autoprofile_from_stdin(
-    outfile, expected_outfile,
-) -> None:
+        outfile, expected_outfile, prof_mod, view) -> None:
     """
     Test the profiling of a script read from stdin.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_dpath = ub.Path(tmpdir)
 
+        kp_cmd = [sys.executable, '-m', 'kernprof', '-l']
+        if prof_mod:
+            kp_cmd += ['-p' 'test_mod.submod1,test_mod.subpkg.submod3']
+        if outfile:
+            kp_cmd += ['-o', outfile]
+        if view:
+            kp_cmd += ['-v']
+        kp_cmd += ['-']
         with ub.ChDir(temp_dpath):
             script_fpath = _write_demo_module(ub.Path())
-
-            args = [sys.executable, '-m', 'kernprof',
-                    '-p', 'test_mod.submod1,test_mod.subpkg.submod3', '-l']
-            if outfile:
-                args += ['-o', outfile]
-            args += ['-']
-            proc = subprocess.run(args,
+            proc = subprocess.run(kp_cmd,
                                   input=script_fpath.read_text(),
                                   text=True,
                                   capture_output=True)
@@ -559,25 +562,28 @@ def test_autoprofile_from_stdin(
             proc.check_returncode()
 
         outfile, = temp_dpath.glob(expected_outfile)
-        args = [sys.executable, '-m', 'line_profiler', str(outfile)]
-        proc = ub.cmd(args)
-        raw_output = proc.stdout
-        print(raw_output)
-        proc.check_returncode()
+        if view:
+            raw_output = proc.stdout
+        else:
+            lp_cmd = [sys.executable, '-m', 'line_profiler', str(outfile)]
+            proc = ub.cmd(lp_cmd)
+            raw_output = proc.stdout
+            print(raw_output)
+            proc.check_returncode()
 
-    assert 'Function: add_one' in raw_output
+    assert ('Function: add_one' in raw_output) == prof_mod
     assert 'Function: add_two' not in raw_output
-    assert 'Function: add_three' in raw_output
-    assert 'Function: main' not in raw_output
+    assert ('Function: add_three' in raw_output) == prof_mod
+    # If we're calling a separate process to view the results, the
+    # script file will already have been deleted
+    assert ('Function: main' in raw_output) == view
 
 
 @pytest.mark.parametrize(
     ('outfile', 'expected_outfile'),
     [(None, 'kernprof-command-*.lprof'),
      ('test-command.lprof', 'test-command.lprof')])
-def test_autoprofile_from_inlined_script(
-    outfile, expected_outfile,
-) -> None:
+def test_autoprofile_from_inlined_script(outfile, expected_outfile) -> None:
     """
     Test the profiling of an inlined script (supplied with the `-c`
     flag).
@@ -587,32 +593,29 @@ def test_autoprofile_from_inlined_script(
 
         _write_demo_module(temp_dpath)
 
-        inlined_script = (
-            'from test_mod import submod1, submod2; '
-            'from test_mod.subpkg import submod3; '
-            'import statistics; '
-            'data = [1, 2, 3]; '
-            'val = submod1.add_one(data); '
-            'val = submod2.add_two(val); '
-            'val = submod3.add_three(val); '
-            'result = statistics.harmonic_mean(val); '
-            'print(result); '
-        )
-        prof_file = 'test-command.lprof'
+        inlined_script = ('from test_mod import submod1, submod2; '
+                          'from test_mod.subpkg import submod3; '
+                          'import statistics; '
+                          'data = [1, 2, 3]; '
+                          'val = submod1.add_one(data); '
+                          'val = submod2.add_two(val); '
+                          'val = submod3.add_three(val); '
+                          'result = statistics.harmonic_mean(val); '
+                          'print(result);')
 
-        args = [sys.executable, '-m', 'kernprof',
-                '-p', 'test_mod.submod1,test_mod.subpkg.submod3', '-l']
+        kp_cmd = [sys.executable, '-m', 'kernprof',
+                  '-p', 'test_mod.submod1,test_mod.subpkg.submod3', '-l']
         if outfile:
-            args += ['-o', outfile]
-        args += ['-c', inlined_script]
-        proc = ub.cmd(args, cwd=temp_dpath, verbose=2)
+            kp_cmd += ['-o', outfile]
+        kp_cmd += ['-c', inlined_script]
+        proc = ub.cmd(kp_cmd, cwd=temp_dpath, verbose=2)
         print(proc.stdout)
         print(proc.stderr)
         proc.check_returncode()
 
         outfile, = temp_dpath.glob(expected_outfile)
-        args = [sys.executable, '-m', 'line_profiler', str(outfile)]
-        proc = ub.cmd(args)
+        lp_cmd = [sys.executable, '-m', 'line_profiler', str(outfile)]
+        proc = ub.cmd(lp_cmd)
         raw_output = proc.stdout
         print(raw_output)
         proc.check_returncode()


### PR DESCRIPTION
This PR is inspired by #323, which added the `-m` option to `kernprof` so that one can profile the execution of modules and packages. Much like how `kernprof <script>` parallels `python <script>`, and `kernprof -m <module>` `python -m <module>`, there may be use-cases that call for similar parallels for:
- `python -c <code>` (running literal code), and
- `... | python -` or `python - <<<"..."` (running code from `stdin`).

Hence this PR which adds to `kernprof`:
- Support for the special option `-c` (like how `-m` is implemented), which terminates the parsing of options and runs the following argument as literal Python code, and
- Support for the special script name `-`, which prompts `kernprof` to read from `stdin`.

It is implemented by a minor refactoring, which writes the received code to a temporary file and profiles that instead.

2 tests are also added:
- `test_autoprofile_from_stdin()`: test for `... | kernprof -`.
- `test_autoprofile_from_inlined_script()`: test for `kernprof -c <code>`.

**EDIT 6 May**: added documentations on the `-m`, `-c`, and `-` invocations for `kernprof`.