### PR TITLE
FIX: `kernprof -m`: presence of the executed module as `sys.modules['__main__']`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changes
 * FIX: Fixed auto-profiling of async function definitions #330
 * ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script; also made it possible for profiling targets to be supplied across multiple ``-p`` flags
 * FIX: Fixed explicit profiling of class methods; added handling for profiling static, bound, and partial methods, ``functools.partial`` objects, (cached) properties, and async generator functions
+* FIX: Fixed namespace bug when running ``kernprof -m`` on certain modules (e.g. ``calendar`` on Python 3.12+)
 
 4.2.0
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changes
 * FIX: Fixed auto-profiling of async function definitions #330
 * ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script; also made it possible for profiling targets to be supplied across multiple ``-p`` flags
 * FIX: Fixed explicit profiling of class methods; added handling for profiling static, bound, and partial methods, ``functools.partial`` objects, (cached) properties, and async generator functions
-* FIX: Fixed namespace bug when running ``kernprof -m`` on certain modules (e.g. ``calendar`` on Python 3.12+)
+* FIX: Fixed namespace bug when running ``kernprof -m`` on certain modules (e.g. ``calendar`` on Python 3.12+).
 
 4.2.0
 ~~~~~

--- a/kernprof.py
+++ b/kernprof.py
@@ -470,7 +470,8 @@ def main(args=None):
     try:
         try:
             execfile_ = execfile
-            rmod_ = run_module
+            rmod_ = functools.partial(run_module,
+                                      run_name='__main__', alter_sys=True)
             ns = locals()
             if options.prof_mod and options.line_by_line:
                 from line_profiler.autoprofile import autoprofile
@@ -487,13 +488,11 @@ def main(args=None):
                                 profile_imports=options.prof_imports,
                                 as_module=module is not None)
             elif module and options.builtin:
-                run_module(options.script, ns, '__main__')
+                rmod_(options.script, ns)
             elif options.builtin:
                 execfile(script_file, ns, ns)
             elif module:
-                prof.runctx(f'rmod_({options.script!r}, globals(), "__main__")',
-                            ns,
-                            ns)
+                prof.runctx(f'rmod_({options.script!r}, globals())', ns, ns)
             else:
                 prof.runctx('execfile_(%r, globals())' % (script_file,), ns, ns)
         except (KeyboardInterrupt, SystemExit):

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -107,17 +107,16 @@ def run(script_file, ns, prof_mod, profile_imports=False, as_module=False):
     if as_module:
         Profiler = AstTreeModuleProfiler
         module_name = modpath_to_modname(script_file)
-        assert module_name is not None
+        if not module_name:
+            raise ModuleNotFoundError(f'script_file = {script_file!r}: '
+                                      'cannot find corresponding module')
 
         module_obj = types.ModuleType(module_name)
         namespace = vars(module_obj)
         namespace.update(ns)
 
         # Set the `__spec__` correctly
-        spec = getattr(sys.modules.get(module_name), '__spec__', None)
-        if spec is None:
-            spec = importlib.util.find_spec(module_name)
-        module_obj.__spec__ = spec
+        module_obj.__spec__ = importlib.util.find_spec(module_name)
 
         # Set the module object to `sys.modules` via a callback, and
         # then restore it via the context manager

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -44,11 +44,16 @@ profiles it with autoprofile.
     python -m kernprof -p demo.py -l demo.py
     python -m line_profiler -rmt demo.py.lprof
 """
-
+import contextlib
+import functools
+import importlib.util
+import operator
+import sys
 import types
 from .ast_tree_profiler import AstTreeProfiler
 from .run_module import AstTreeModuleProfiler
 from .line_profiler_utils import add_imported_function_or_module
+from .util_static import modpath_to_modname
 
 PROFILER_LOCALS_NAME = 'prof'
 
@@ -92,10 +97,43 @@ def run(script_file, ns, prof_mod, profile_imports=False, as_module=False):
         as_module (bool):
             Whether we're running script_file as a module
     """
-    Profiler = AstTreeModuleProfiler if as_module else AstTreeProfiler
+    @contextlib.contextmanager
+    def restore_dict(d, target=None):
+        copy = d.copy()
+        yield target
+        d.clear()
+        d.update(copy)
+
+    if as_module:
+        Profiler = AstTreeModuleProfiler
+        module_name = modpath_to_modname(script_file)
+        assert module_name is not None
+
+        module_obj = types.ModuleType(module_name)
+        namespace = vars(module_obj)
+        namespace.update(ns)
+
+        # Set the `__spec__` correctly
+        spec = getattr(sys.modules.get(module_name), '__spec__', None)
+        if spec is None:
+            spec = importlib.util.find_spec(module_name)
+        module_obj.__spec__ = spec
+
+        # Set the module object to `sys.modules` via a callback, and
+        # then restore it via the context manager
+        callback = functools.partial(
+            operator.setitem, sys.modules, '__main__', module_obj)
+        ctx = restore_dict(sys.modules, callback)
+    else:
+        Profiler = AstTreeProfiler
+        namespace = ns
+        ctx = contextlib.nullcontext(lambda: None)
+
     profiler = Profiler(script_file, prof_mod, profile_imports)
     tree_profiled = profiler.profile()
 
     _extend_line_profiler_for_profiling_imports(ns[PROFILER_LOCALS_NAME])
     code_obj = compile(tree_profiled, script_file, 'exec')
-    exec(code_obj, ns, ns)
+    with ctx as callback:
+        callback()
+        exec(code_obj, namespace, namespace)

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -1,3 +1,5 @@
+import os
+import re
 import shlex
 import sys
 import tempfile
@@ -71,8 +73,9 @@ def test_kernprof_m_parsing(
         return
     else:
         proc.check_returncode()
-    expected_output = expected_output.replace('__MYMOD__', repr(str(mod)))
-    assert proc.stdout.startswith(expected_output)
+    expected_output = re.escape(expected_output).replace(
+        '__MYMOD__', "'.*{}'".format(re.escape(os.path.sep + mod.name)))
+    assert re.match('^' + expected_output, proc.stdout)
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 11),


### PR DESCRIPTION
Motivation
----

`kernprof -m` as it is now fails to address edge cases where the executed module is expected to be found at `sys.modules['__main__']`. One such cases is for the `@enum.global_enum` decorator, which searches `sys.modules` for the module whither to insert the enum instances. This causes [use-cases like `kernprof -m calendar`](https://github.com/pyutils/line_profiler/pull/337#issuecomment-2837178985) to fail. Notably, [a similar failure pattern](https://github.com/python/cpython/issues/103935#issuecomment-1526102367) is seen with even Python `stdlib` modules.

Changes
----

The key point of failure lies with how `kernprof` uses `runpy.run_module()` without the optional `alter_sys` argument. Since it defaults to false, the executed module is not inserted into `sys.modules`, and thus the aforementioned use-case fails. Hence, this PR implements the following changes:
- `CHANGELOG.rst`:  
  Added entry
- `kernprof.py::main()`:  
  Now calling `runpy.run_module()` with `alter_sys = True` to maintain compatibility with code expecting the executed module to be found at `sys.modules['__main__']`
- `line_profiler/autoprofile/autoprofile.py::run()`:  
  Updated implementation to do the equivalent of `runpy.run_module(alter_sys=True)`
- `tests/test_kernprof.py`:
  - `test_kernprof_m_parsing()`:
    - Updated implementation to expect the correct `sys.argv[0]` (real path to the module file)
    - Replaced `tempfile.mkdtemp()` with `tempfile.TemporaryDirectory`
  - `test_kernprof_m_sys_modules()`:  
    New test for compatibility with tools (e.g. `@enum.global_enum`) expecting the executed module to be found at `sys.modules['__main__']`