### PR TITLE
FIX: fixed cleanup code in `@contextlib.contextmanager`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changes
 * ENH: Added CLI argument ``-m`` to ``kernprof`` for running a library module as a script; also made it possible for profiling targets to be supplied across multiple ``-p`` flags
 * FIX: Fixed explicit profiling of class methods; added handling for profiling static, bound, and partial methods, ``functools.partial`` objects, (cached) properties, and async generator functions
 * FIX: Fixed namespace bug when running ``kernprof -m`` on certain modules (e.g. ``calendar`` on Python 3.12+).
+* FIX: Fixed ``@contextlib.contextmanager`` bug where the cleanup code (e.g. restoration of ``sys`` attributes) is not run if exceptions occurred inside the context
 
 4.2.0
 ~~~~~

--- a/kernprof.py
+++ b/kernprof.py
@@ -249,8 +249,10 @@ def _restore_list(lst):
     [1, 2, 3]
     """
     old = lst.copy()
-    yield
-    lst[:] = old
+    try:
+        yield
+    finally:
+        lst[:] = old
 
 
 def pre_parse_single_arg_directive(args, flag, sep='--'):

--- a/kernprof.py
+++ b/kernprof.py
@@ -255,7 +255,7 @@ class _restore_list:
         self.old = self.lst.copy()
 
     def __exit__(self, *_, **__):
-        self.lst[:] = self.old
+        self.old, self.lst[:] = None, self.old
 
     def __call__(self, func):
         @functools.wraps(func)

--- a/kernprof.py
+++ b/kernprof.py
@@ -248,13 +248,14 @@ class _restore_list:
     """
     def __init__(self, lst):
         self.lst = lst
-        self.contexts = []
+        self.old = None
 
     def __enter__(self):
-        self.contexts.append(self.lst.copy())
+        assert self.old is None
+        self.old = self.lst.copy()
 
     def __exit__(self, *_, **__):
-        self.lst[:] = self.contexts.pop()
+        self.lst[:] = self.old
 
     def __call__(self, func):
         @functools.wraps(func)

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -97,14 +97,19 @@ def run(script_file, ns, prof_mod, profile_imports=False, as_module=False):
         as_module (bool):
             Whether we're running script_file as a module
     """
-    @contextlib.contextmanager
-    def restore_dict(d, target=None):
-        copy = d.copy()
-        try:
-            yield target
-        finally:
-            d.clear()
-            d.update(copy)
+    class restore_dict:
+        def __init__(self, d, target=None):
+            self.d = d
+            self.target = target
+            self.contexts = []
+
+        def __enter__(self):
+            self.contexts.append(self.d.copy())
+            return self.target
+
+        def __exit__(self, *_, **__):
+            self.d.clear()
+            self.d.update(self.contexts.pop())
 
     if as_module:
         Profiler = AstTreeModuleProfiler

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -101,15 +101,17 @@ def run(script_file, ns, prof_mod, profile_imports=False, as_module=False):
         def __init__(self, d, target=None):
             self.d = d
             self.target = target
-            self.contexts = []
+            self.copy = None
 
         def __enter__(self):
-            self.contexts.append(self.d.copy())
+            assert self.copy is None
+            self.copy = self.d.copy()
             return self.target
 
         def __exit__(self, *_, **__):
             self.d.clear()
-            self.d.update(self.contexts.pop())
+            self.d.update(self.copy)
+            self.copy = None
 
     if as_module:
         Profiler = AstTreeModuleProfiler

--- a/line_profiler/autoprofile/autoprofile.py
+++ b/line_profiler/autoprofile/autoprofile.py
@@ -100,9 +100,11 @@ def run(script_file, ns, prof_mod, profile_imports=False, as_module=False):
     @contextlib.contextmanager
     def restore_dict(d, target=None):
         copy = d.copy()
-        yield target
-        d.clear()
-        d.update(copy)
+        try:
+            yield target
+        finally:
+            d.clear()
+            d.update(copy)
 
     if as_module:
         Profiler = AstTreeModuleProfiler

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -50,9 +50,12 @@ def check_timings(prof):
     timings = prof.get_stats().timings
     assert not any(timings.values()), ('Expected no timing entries, '
                                        f'got {timings!r}')
-    yield prof
-    timings = prof.get_stats().timings
-    assert any(timings.values()), f'Expected timing entries, got {timings!r}'
+    try:
+        yield prof
+    finally:
+        timings = prof.get_stats().timings
+        assert (any(timings.values()),
+                f'Expected timing entries, got {timings!r}')
 
 
 def test_init():

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -41,21 +41,28 @@ def strip(s):
     return textwrap.dedent(s).strip('\n')
 
 
-@contextlib.contextmanager
-def check_timings(prof):
+class check_timings:
     """
     Verify that the profiler starts without timing data and ends with
     some.
     """
-    timings = prof.get_stats().timings
-    assert not any(timings.values()), ('Expected no timing entries, '
-                                       f'got {timings!r}')
-    try:
-        yield prof
-    finally:
-        timings = prof.get_stats().timings
-        assert (any(timings.values()),
-                f'Expected timing entries, got {timings!r}')
+    def __init__(self, prof):
+        self.prof = prof
+
+    def __enter__(self):
+        timings = self.timings
+        assert not any(timings.values()), (
+            f'Expected no timing entries, got {timings!r}')
+        return self.prof
+
+    def __exit__(self, *_, **__):
+        timings = self.timings
+        assert any(timings.values()), (
+            f'Expected timing entries, got {timings!r}')
+
+    @property
+    def timings(self):
+        return self.prof.get_stats().timings
 
 
 def test_init():


### PR DESCRIPTION
Just noticed that I made the same mistake in #323, #332, and #339, where `@contextlib.contextmanager` is used to wrap generator functions to construct context managers: the `yield` statement and the subsequent cleanup code wasn't wrapped in a `try`–`finally` block, so the cleanup is eschewed if any exception occurred inside the `with` block/decorated function.

This PR fixes the bug in three functions:
- `kernprof.py::_restore_list()` (used by `main()`)
- `line_profiler/autoprofile/autoprofile.py::run.<locals>.restore_dict()`
- `tests/test_line_profiler.py::check_timings()`

One test is added to verify that the old behavior is problematic and is fixed by the PR:
- `tests/test_kernprof.py::test_kernprof_sys_restoration()`

Sorry for any inconvenience caused.