### PR TITLE
Prevent encoding error in IPython extension in Windows

### DIFF
--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -157,7 +157,7 @@ class LineProfilerMagics(Magics):
 
         text_file = opts.T[0]
         if text_file:
-            pfile = open(text_file, "w")
+            pfile = open(text_file, "w", encoding="utf-8")
             pfile.write(output)
             pfile.close()
             print(f"\n*** Profile printout saved to text file {text_file!r}. {message}")


### PR DESCRIPTION
When using the `%lprun` magic in Windows, and trying to store the profile results in a file, the following exception was raised if the functions profiled contain non-ASCII characters:

```python
UnicodeEncodeError                        Traceback (most recent call last)
Cell In[5], line 1

File ...\.conda\Lib\site-packages\IPython\core\interactiveshell.py:2482, in InteractiveShell.run_line_magic(self, magic_name, line, _stack_depth)
   2480     kwargs['local_ns'] = self.get_local_scope(stack_depth)
   2481 with self.builtin_trap:
-> 2482     result = fn(*args, **kwargs)
   2484 # The code below prevents the output from being displayed
   2485 # when using magics with decorator @output_can_be_silenced
   2486 # when the last Python token in the expression is a ';'.
   2487 if getattr(fn, magic.MAGIC_OUTPUT_CAN_BE_SILENCED, False):

File ...\.conda\Lib\site-packages\line_profiler\ipython_extension.py:161, in LineProfilerMagics.lprun(self, parameter_s)
    159 if text_file:
    160     pfile = open(text_file, "w")
--> 161     pfile.write(output)
    162     pfile.close()
    163     print(f"\n*** Profile printout saved to text file {text_file!r}. {message}")

File ...\.conda\Lib\encodings\cp1252.py:19, in IncrementalEncoder.encode(self, input, final)
     18 def encode(self, input, final=False):
---> 19     return codecs.charmap_encode(input,self.errors,encoding_table)[0]

UnicodeEncodeError: 'charmap' codec can't encode character '\u0394' in position 36719: character maps to <undefined>
```

This is because the default encoding in Windows does not support non-ASCII characters. Thus, the solution (as in #312) is to specify the UTF-8 encoding in the `open` call.