### PR TITLE
FIX: `LineProfiler.last_time` always empty (and sometimes errors out)

### DIFF
--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -471,7 +471,10 @@ cdef class LineProfiler:
 
     @property
     def c_last_time(self):
-        return (<dict>self._c_last_time)[threading.get_ident()]
+        try:
+            return (<dict>self._c_last_time)[threading.get_ident()]
+        except KeyError:  # We haven't actually profiled anything yet
+            return {}
 
     @property
     def code_map(self):
@@ -500,7 +503,7 @@ cdef class LineProfiler:
         line_profiler 4.0 no longer directly maintains last_time, but this will
         construct something similar for backwards compatibility.
         """
-        c_last_time = (<dict>self._c_last_time)[threading.get_ident()]
+        c_last_time = self.c_last_time
         code_hash_map = self.code_hash_map
         py_last_time = {}
         for code, code_hashes in code_hash_map.items():

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -471,10 +471,19 @@ cdef class LineProfiler:
 
     @property
     def c_last_time(self):
+        """
+        Raises:
+            KeyError
+                If no profiling data is available on the current thread.
+        """
         try:
             return (<dict>self._c_last_time)[threading.get_ident()]
-        except KeyError:  # We haven't actually profiled anything yet
-            return {}
+        except KeyError as e:
+            # We haven't actually profiled anything yet
+            raise (KeyError('No profiling data on the current thread '
+                            '(`threading.get_ident()` = '
+                            f'{threading.get_ident()})')
+                   .with_traceback(e.__traceback__)) from None
 
     @property
     def code_map(self):

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -504,12 +504,11 @@ cdef class LineProfiler:
         construct something similar for backwards compatibility.
         """
         c_last_time = self.c_last_time
-        code_hash_map = self.code_hash_map
         py_last_time = {}
-        for code, code_hashes in code_hash_map.items():
-            for code_hash in code_hashes:
-                if code_hash in c_last_time:
-                    py_last_time[code] = c_last_time[code_hash]
+        for code in self.code_hash_map:
+            block_hash = hash(code.co_code)
+            if block_hash in c_last_time:
+                py_last_time[code] = c_last_time[block_hash]
         return py_last_time
 
 

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -80,6 +80,30 @@ def test_init():
     }
 
 
+def test_last_time():
+    """
+    Test that `LineProfiler.c_last_time` and `LineProfiler.last_time`
+    are consistent.
+    """
+    prof = LineProfiler()
+
+    @prof
+    def func():
+        return prof.c_last_time.copy(), prof.last_time.copy()
+
+    # These are always empty outside a profiling context
+    # (hence the need of the above function to capture the transient
+    # values)
+    assert not prof.c_last_time
+    assert not prof.last_time
+    # Inside `func()`, both should get an entry therefor
+    clt, lt = func()
+    assert not prof.c_last_time
+    assert not prof.last_time
+    assert set(clt) == {hash(func.__wrapped__.__code__.co_code)}
+    assert set(lt) == {func.__wrapped__.__code__}
+
+
 def test_enable_disable():
     lp = LineProfiler()
     assert lp.enable_count == 0


### PR DESCRIPTION
The bug(s)
----
The behaviors of `LineProfiler.c_last_time` and `LineProfiler.last_time` are inconsistent:
```python
import line_profiler

prof = line_profiler.LineProfiler()

...

@prof
def func():
    return prof.c_last_time.copy(), prof.last_time.copy()

# They are always empty outside a profiled scope
assert not prof.c_last_time  # This may give a `KeyError` if no profiling was done on the thread
assert not prof.last_time
clt, lt = func()
assert not prof.c_last_time
assert not prof.last_time

# But not inside the profiled scope (like `func()`)
assert clt
assert lt  # This assertion fails, `.last_time` empty despite `c_last_time` being not
assert set(clt) == {hash(f.__wrapped__.__code__.co_code)}
assert set(lt) == {f.__wrapped__.__code__}
```

The causes
----
### `KeyError`

Both `.c_last_time` and `.last_time` directly access the underlying `._c_last_time` with the key `threading.get_ident()`. However, it is not necessarily set if `line_profiler/_line_profiler.pyx::python_trace_callback()` hasn't been called on the thread yet.

### Failing assertion

The implementation of `line_profiler/_line_profiler.pyx::LineProfiler.last_time` (type: `dict[CodeType, LastTime]`) basically scans `.c_last_time` (type: `dict[int, LastTime]`) for *line*-hash keys matching values in `.code_hash_map` (type: `dict[CodeType, list[int]]`). However, as seen in `python_trace_callback()` in the same file (and hinted at in the above example), the keys in `.c_last_time` are *block* hashes (hashes of the whole bytecode) not line hashes (re-hashes thereof incorporating line-number information). Hence nothing matches and the empty result.

The fix
----
- `.last_time` has been fixed to do `block_hash = hash(code.co_code)` instead of to scan the `code_hashes` (which are line hashes) corresponding to `code` in `.code_hash_map`.
- `.c_last_time` now catches the `KeyError` when accessing `._c_last_time` and ~~gracefully returns an empty dict~~ **(updated 29 May) attaches a more informative error message**.
- `.last_time` now uses `.c_last_time` instead of directly accessing `._c_last_time`.
- To verify the fix, the test `tests/test_line_profiler.py::test_last_time()` is added.

Performance implications
----
Should be minimal since `.last_time` is documented as a legacy/backward-compatible API, and nothing else directly uses `.c_last_time`. (The performance-critical `LineProfiler.disable()` and `python_trace_callback()` both use `._c_last_time` directly.)

Disclaimers
----
- Again, `.last_time` is documented as legacy, so one may argue that the PR is unnecessary. But since the API is here, I'd argue it should either be fixed or dropped.
- Haven't included a CHANGELOG entry since this is probably too small a fix to warrant that (as indicated by the last 3 merged PRs (#341, #343, #342)).