### PR TITLE
Use co_qualname in reporting when possible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changes
 * FIX: Fixed namespace bug when running ``kernprof -m`` on certain modules (e.g. ``calendar`` on Python 3.12+).
 * FIX: Fixed ``@contextlib.contextmanager`` bug where the cleanup code (e.g. restoration of ``sys`` attributes) is not run if exceptions occurred inside the context
 * ENH: Added CLI arguments ``-c`` to ``kernprof`` for (auto-)profiling module/package/inline-script execution instead of that of script files; passing ``'-'`` as the script-file name now also reads from and profiles ``stdin``
+* ENH: In Python >=3.11, profiled objects are reported using their qualified name.
 
 4.2.0
 ~~~~~

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -155,14 +155,18 @@ else:
 
 def label(code):
     """
-    Return a (filename, first_lineno, func_name) tuple for a given code object.
+    Return a (filename, first_lineno, qual_name) tuple for a given code object.
 
-    This is the same labelling as used by the cProfile module in Python 2.5.
+    This is the similar labelling as used by the cProfile module in Python 2.5.
     """
     if isinstance(code, str):
         return ('~', 0, code)    # built-in functions ('~' sorts at the end)
     else:
-        return (code.co_filename, code.co_firstlineno, code.co_name)
+        try:
+            # Python >=3.11a1
+            return (code.co_filename, code.co_firstlineno, code.co_qualname)
+        except AttributeError:
+            return (code.co_filename, code.co_firstlineno, code.co_name)
 
 
 cpdef _code_replace(func, co_code):


### PR DESCRIPTION
Report with co-qualname as discussed in https://github.com/pyutils/line_profiler/pull/337