### PR TITLE
FIX: aggregating profiling data from duplicate code objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changes
     like class methods and properties
   * ``LineProfiler`` can now be used as a class decorator
 * FIX: Fixed line tracing for Cython code; superseded use of the legacy tracing system with ``sys.monitoring``
+* ENH: Fixed edge case where :py:meth:`LineProfiler.get_stats()` neglects data from duplicate code objects (#348)
 
 4.2.0
 ~~~~~


### PR DESCRIPTION
Closes #348.

Code changes
----
- `line_profiler/_line_profiler.pyx::LineProfiler.get_stats()`:  
  Refactored to aggregate profiling data for duplicate (but distinct) code objects, which have separate entries in `.c_code_map` and `.code_hash_map` but is hashed to the same key by `label()` in the output `LineStats` object

Test changes
----
- `tests/test_line_profiler.py::test_duplicate_code_objects()`:  
  New test that the bug described in the issue is fixed