### PR TITLE
FIX: Update hash tables of affected profiler instances when rewriting code objects 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changes
 * ENH: In Python >=3.11, profiled objects are reported using their qualified name.
 * ENH: Highlight final summary using rich if enabled
 * ENH: Made it possible to use multiple profiler instances simultaneously
+* ENH: Fixed edge case where :py:meth:`LineProfiler.get_stats()` neglects data from duplicate code objects (#348)
 
 4.2.0
 ~~~~~

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -25,6 +25,7 @@ from libcpp.unordered_map cimport unordered_map
 import threading
 import opcode
 import types
+from weakref import WeakSet
 
 NOP_VALUE: int = opcode.opmap['NOP']
 
@@ -253,8 +254,12 @@ cdef class LineProfiler:
     cdef public double timer_unit
     cdef public object threaddata
 
-    # This is shared between instances and threads
+    # These are shared between instances and threads
+    # type: dict[int, set[LineProfiler]], int = thread id
     _all_active_instances = {}
+    # type: dict[bytes, tuple[int, weakref.WeakSet[LineProfiler]]]
+    # Wher bytes = bytecode, int = padding length
+    _all_instances_by_bcodes = {}
 
     def __init__(self, *functions):
         self.functions = []
@@ -288,29 +293,74 @@ cdef class LineProfiler:
                 warnings.warn("Could not extract a code object for the object %r" % (func,))
                 return
 
-        if code.co_code in self.dupes_map:
-            self.dupes_map[code.co_code] += [code]
-            # code hash already exists, so there must be a duplicate function. add no-op
-            co_padding : bytes = NOP_BYTES * (len(self.dupes_map[code.co_code]) + 1)
-            co_code = code.co_code + co_padding
-            CodeType = type(code)
+        original_code_obj = code
+        original_bcode = code.co_code
+        # Note: if we are to alter the code object, other profilers
+        # which previously added this function would still expect the
+        # old bytecode, and thus will not see anything when the function
+        # is executed;
+        # hence:
+        # - When doing bytecode padding, take into account all instances
+        #   which refers to the same base bytecode to ensure
+        #   disambiguation
+        # - Update all existing instances referring to the old code
+        #   object
+        try:
+            npad, neighbors = self._all_instances_by_bcodes[original_bcode]
+            neighbors.add(self)
+        except KeyError:
+            npad = 0
+            neighbors = WeakSet({self})
+            self._all_instances_by_bcodes[original_bcode] = (0, neighbors)
+        if npad:
+            # Code hash already exists, so there must be a duplicate
+            # function (on some instance);
+            # add no-op
+            co_code = original_bcode + NOP_BYTES * npad
             code = _code_replace(func, co_code=co_code)
             try:
                 func.__code__ = code
             except AttributeError as e:
                 func.__func__.__code__ = code
-        else:
-            self.dupes_map[code.co_code] = [code]
-        # TODO: Since each line can be many bytecodes, this is kinda inefficient
-        # See if this can be sped up by not needing to iterate over every byte
-        for offset, byte in enumerate(code.co_code):
-            code_hash = compute_line_hash(hash((code.co_code)), PyCode_Addr2Line(<PyCodeObject*>code, offset))
-            if not self._c_code_map.count(code_hash):
-                try:
-                    self.code_hash_map[code].append(code_hash)
-                except KeyError:
-                    self.code_hash_map[code] = [code_hash]
-                self._c_code_map[code_hash]
+        try:
+            self.dupes_map[original_bcode].append(code)
+        except KeyError:
+            self.dupes_map[original_bcode] = [code]
+        # If we padded the bytecode, identify other instances profiling
+        # the same CODE OBJECT, replacing the original code object with
+        # the new one and marking those instances for further updates
+        instances_to_update = {self}
+        if npad:
+            for instance in neighbors:
+                code_objs = instance.dupes_map[original_bcode]
+                for i, code_obj in enumerate(code_objs):
+                    if code_obj is original_code_obj:
+                        instances_to_update.add(instance)
+                        code_objs[i] = code
+        # TODO: Since each line can be many bytecodes, this is kinda
+        # inefficient
+        # See if this can be sped up by not needing to iterate over
+        # every byte
+        code_hashes = []
+        for offset, _ in enumerate(code.co_code):
+            code_hashes.append(
+                compute_line_hash(
+                    hash(code.co_code),
+                    PyCode_Addr2Line(<PyCodeObject*>code, offset)))
+        # Update `._c_code_map` and `.code_hash_map` with the new line
+        # hashes on `self` and other instances profiling the same
+        # function
+        for instance in instances_to_update:
+            prof = <LineProfiler>instance
+            try:
+                line_hashes = prof.code_hash_map[code]
+            except KeyError:
+                line_hashes = prof.code_hash_map[code] = []
+            for code_hash in code_hashes:
+                line_hash = <int64>code_hash
+                if not prof._c_code_map.count(line_hash):
+                    line_hashes.append(line_hash)
+                    prof._c_code_map[line_hash]
 
         self.functions.append(func)
 

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -321,6 +321,7 @@ cdef class LineProfiler:
         except KeyError:
             npad = 0
         self._all_paddings[base_co_code] = max(npad, npad_code) + 1
+        need_padding = npad > npad_code
         try:
             neighbors = self._all_instances_by_funcs[func_id]
             neighbors.add(self)
@@ -331,7 +332,7 @@ cdef class LineProfiler:
             self.dupes_map[base_co_code].append(code)
         except KeyError:
             self.dupes_map[base_co_code] = [code]
-        if npad > npad_code:
+        if need_padding:
             # Code hash already exists, so there must be a duplicate
             # function (on some instance);
             # (re-)pad with no-op
@@ -352,9 +353,9 @@ cdef class LineProfiler:
                     hash(co_code),
                     PyCode_Addr2Line(<PyCodeObject*>code, offset)))
         # Update `._c_code_map` and `.code_hash_map` with the new line
-        # hashes on `self` and other instances profiling the same
-        # function
-        for instance in neighbors:
+        # hashes on `self` (and other instances profiling the same
+        # function if we padded the bytecode)
+        for instance in (neighbors if need_padding else (self,)):
             prof = <LineProfiler>instance
             try:
                 line_hashes = prof.code_hash_map[code]

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -257,9 +257,10 @@ cdef class LineProfiler:
     # These are shared between instances and threads
     # type: dict[int, set[LineProfiler]], int = thread id
     _all_active_instances = {}
-    # type: dict[bytes, tuple[int, weakref.WeakSet[LineProfiler]]]
-    # Wher bytes = bytecode, int = padding length
-    _all_instances_by_bcodes = {}
+    # type: dict[bytes, int], bytes = bytecode
+    _all_paddings = {}
+    # type: dict[int, weakref.WeakSet[LineProfiler]], int = func id
+    _all_instances_by_funcs = {}
 
     def __init__(self, *functions):
         self.functions = []
@@ -285,16 +286,17 @@ cdef class LineProfiler:
             )
         try:
             code = func.__code__
+            func_id = id(func)
         except AttributeError:
             try:
                 code = func.__func__.__code__
+                func_id = id(func.__func__)
             except AttributeError:
                 import warnings
                 warnings.warn("Could not extract a code object for the object %r" % (func,))
                 return
 
-        original_code_obj = code
-        original_bcode = code.co_code
+        co_code: bytes = code.co_code
         # Note: if we are to alter the code object, other profilers
         # which previously added this function would still expect the
         # old bytecode, and thus will not see anything when the function
@@ -302,55 +304,49 @@ cdef class LineProfiler:
         # hence:
         # - When doing bytecode padding, take into account all instances
         #   which refers to the same base bytecode to ensure
-        #   disambiguation
-        # - Update all existing instances referring to the old code
-        #   object
+        #   disambiguation (done by a class-level attribute)
+        # - Update all existing instances referring to the same function
+        #   to point to the new code object
         try:
-            npad, neighbors = self._all_instances_by_bcodes[original_bcode]
-            neighbors.add(self)
+            npad = self._all_paddings[co_code]
+            self._all_paddings[co_code] = npad + 1
         except KeyError:
             npad = 0
-            neighbors = WeakSet({self})
-            self._all_instances_by_bcodes[original_bcode] = (0, neighbors)
+            self._all_paddings[co_code] = 1
+        try:
+            neighbors = self._all_instances_by_funcs[func_id]
+            neighbors.add(self)
+        except KeyError:
+            neighbors = self._all_instances_by_funcs[func_id] = WeakSet({self})
+        # Maintain `.dupes_map` (legacy)
+        try:
+            self.dupes_map[co_code].append(code)
+        except KeyError:
+            self.dupes_map[co_code] = [code]
         if npad:
             # Code hash already exists, so there must be a duplicate
             # function (on some instance);
             # add no-op
-            co_code = original_bcode + NOP_BYTES * npad
+            co_code += NOP_BYTES * npad
             code = _code_replace(func, co_code=co_code)
             try:
                 func.__code__ = code
             except AttributeError as e:
                 func.__func__.__code__ = code
-        try:
-            self.dupes_map[original_bcode].append(code)
-        except KeyError:
-            self.dupes_map[original_bcode] = [code]
-        # If we padded the bytecode, identify other instances profiling
-        # the same CODE OBJECT, replacing the original code object with
-        # the new one and marking those instances for further updates
-        instances_to_update = {self}
-        if npad:
-            for instance in neighbors:
-                code_objs = instance.dupes_map[original_bcode]
-                for i, code_obj in enumerate(code_objs):
-                    if code_obj is original_code_obj:
-                        instances_to_update.add(instance)
-                        code_objs[i] = code
         # TODO: Since each line can be many bytecodes, this is kinda
         # inefficient
         # See if this can be sped up by not needing to iterate over
         # every byte
         code_hashes = []
-        for offset, _ in enumerate(code.co_code):
+        for offset, _ in enumerate(co_code):
             code_hashes.append(
                 compute_line_hash(
-                    hash(code.co_code),
+                    hash(co_code),
                     PyCode_Addr2Line(<PyCodeObject*>code, offset)))
         # Update `._c_code_map` and `.code_hash_map` with the new line
         # hashes on `self` and other instances profiling the same
         # function
-        for instance in instances_to_update:
+        for instance in neighbors:
             prof = <LineProfiler>instance
             try:
                 line_hashes = prof.code_hash_map[code]

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -297,6 +297,15 @@ cdef class LineProfiler:
                 return
 
         co_code: bytes = code.co_code
+        base_co_code: bytes = co_code
+        # Figure out how much padding we need and strip the bytecode
+        # TODO: is there a way to do this faster? `.rstrip()` doesn't
+        # work (reliably) since `NOP_BYTES` should be 2-byte wide
+        npad_code: int = 0
+        nop_len: int = -len(NOP_BYTES)
+        while base_co_code.endswith(NOP_BYTES):
+            base_co_code = base_co_code[:nop_len]
+            npad_code += 1
         # Note: if we are to alter the code object, other profilers
         # which previously added this function would still expect the
         # old bytecode, and thus will not see anything when the function
@@ -308,11 +317,10 @@ cdef class LineProfiler:
         # - Update all existing instances referring to the same function
         #   to point to the new code object
         try:
-            npad = self._all_paddings[co_code]
-            self._all_paddings[co_code] = npad + 1
+            npad = self._all_paddings[base_co_code]
         except KeyError:
             npad = 0
-            self._all_paddings[co_code] = 1
+        self._all_paddings[base_co_code] = max(npad, npad_code) + 1
         try:
             neighbors = self._all_instances_by_funcs[func_id]
             neighbors.add(self)
@@ -320,14 +328,14 @@ cdef class LineProfiler:
             neighbors = self._all_instances_by_funcs[func_id] = WeakSet({self})
         # Maintain `.dupes_map` (legacy)
         try:
-            self.dupes_map[co_code].append(code)
+            self.dupes_map[base_co_code].append(code)
         except KeyError:
-            self.dupes_map[co_code] = [code]
-        if npad:
+            self.dupes_map[base_co_code] = [code]
+        if npad > npad_code:
             # Code hash already exists, so there must be a duplicate
             # function (on some instance);
-            # add no-op
-            co_code += NOP_BYTES * npad
+            # (re-)pad with no-op
+            co_code = base_co_code + NOP_BYTES * npad
             code = _code_replace(func, co_code=co_code)
             try:
                 func.__code__ = code

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -429,35 +429,29 @@ cdef class LineProfiler:
         """
         cdef dict cmap = self._c_code_map
 
-        stats = {}
+        all_entries = {}
         for code in self.code_hash_map:
             entries = []
             for entry in self.code_hash_map[code]:
-                entries += list(cmap[entry].values())
+                entries.extend(cmap[entry].values())
             key = label(code)
 
-            # Merge duplicate line numbers, which occur for branch entrypoints like `if`
-            nhits_by_lineno = {}
-            total_time_by_lineno = {}
+            # Merge duplicate line numbers, which occur for branch
+            # entrypoints like `if`
+            entries_by_lineno = all_entries.setdefault(key, {})
 
             for line_dict in entries:
                  _, lineno, total_time, nhits = line_dict.values()
-                 nhits_by_lineno[lineno] = nhits_by_lineno.setdefault(lineno, 0) + nhits
-                 total_time_by_lineno[lineno] = total_time_by_lineno.setdefault(lineno, 0) + total_time
+                 orig_nhits, orig_total_time = entries_by_lineno.get(
+                     lineno, (0, 0))
+                 entries_by_lineno[lineno] = (orig_nhits + nhits,
+                                              orig_total_time + total_time)
 
-            entries = [(lineno, nhits, total_time_by_lineno[lineno]) for lineno, nhits in nhits_by_lineno.items()]
-            entries.sort()
-
-            # NOTE: v4.x may produce more than one entry per line. For example:
-            #   1:  for x in range(10):
-            #   2:      pass
-            #  will produce a 1-hit entry on line 1, and 10-hit entries on lines 1 and 2
-            #  This doesn't affect `print_stats`, because it uses the last entry for a given line (line number is
-            #  used a dict key so earlier entries are overwritten), but to keep compatability with other tools,
-            #  let's only keep the last entry for each line
-            # Remove all but the last entry for each line
-            entries = list({e[0]: e for e in entries}.values())
-            stats[key] = entries
+        # Aggregate the timing data
+        stats = {
+            key: sorted((line, nhits, time)
+                        for line, (nhits, time) in entries_by_lineno.items())
+            for key, entries_by_lineno in all_entries.items()}
         return LineStats(stats, self.timer_unit)
 
 @cython.boundscheck(False)

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -679,3 +679,37 @@ def test_multiple_profilers_usage():
     assert t2['sum_n'][2][1] == n
     assert t1['sum_n_sq'][2][1] == n
     assert t2['sum_n_cb'][2][1] == n
+
+
+def test_duplicate_code_objects():
+    """
+    Test that results are correctly aggregated between duplicate code
+    objects.
+    """
+    code = textwrap.dedent("""
+    @profile
+    def func(n):
+        x = 0
+        for n in range(1, n + 1):
+            x += n
+        return x
+    """).strip('\n')
+    profile = LineProfiler()
+    # Create and call the function once
+    namespace_1 = {'profile': profile}
+    exec(code, namespace_1)
+    assert 'func' in namespace_1
+    assert len(profile.functions) == 1
+    assert namespace_1['func'].__wrapped__ in profile.functions
+    assert namespace_1['func'](10) == 10 * 11 // 2
+    # Do it again
+    namespace_2 = {'profile': profile}
+    exec(code, namespace_2)
+    assert 'func' in namespace_2
+    assert len(profile.functions) == 2
+    assert namespace_2['func'].__wrapped__ in profile.functions
+    assert namespace_2['func'](20) == 20 * 21 // 2
+    # Check that data from both calls are aggregated
+    # (Entries are represented as tuples `(lineno, nhits, time)`)
+    entries, = profile.get_stats().timings.values()
+    assert entries[-2][1] == 10 + 20

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -41,6 +41,14 @@ def strip(s):
     return textwrap.dedent(s).strip('\n')
 
 
+def get_prof_stats(prof, name='prof', **kwargs):
+    with io.StringIO() as sio:
+        prof.print_stats(sio, **kwargs)
+        output = sio.getvalue()
+        print(f'@{name}:', textwrap.indent(output, '  '), sep='\n\n')
+    return output
+
+
 class check_timings:
     """
     Verify that the profiler starts without timing data and ends with
@@ -252,10 +260,7 @@ def test_classmethod_decorator():
     assert profile.enable_count == 0
     assert len(profile.functions) == 1
     assert Object.foo() == Object().foo() == 'ObjectObject'
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
-    print(output)
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `Object.foo()`
     assert output.endswith('foo')
     line, = (line for line in output.splitlines() if line.endswith('* 2'))
@@ -286,10 +291,7 @@ def test_staticmethod_decorator():
     assert profile.enable_count == 0
     assert len(profile.functions) == 1
     assert Object.foo(3) == Object().foo(3) == 6
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
-    print(output)
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `Object.foo()`
     assert output.endswith('foo')
     line, = (line for line in output.splitlines() if line.endswith('* 2'))
@@ -327,10 +329,7 @@ def test_boundmethod_decorator():
             == profiled_foo_2(2)
             == obj.foo(2)
             == id(obj) * 2)
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
-    print(output)
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `Object.foo()`
     assert output.endswith('foo')
     line, = (line for line in output.splitlines() if line.endswith('* x'))
@@ -363,10 +362,7 @@ def test_partialmethod_decorator():
     assert profile.enable_count == 0
     assert profile.functions == [Object.foo]
     assert obj.foo(1) == obj.bar() == id(obj)
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
-    print(output)
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `Object.foo()` (via `.bar()`)
     assert output.endswith('foo')
     line, = (line for line in output.splitlines() if line.endswith('* x'))
@@ -403,10 +399,7 @@ def test_partial_decorator() -> None:
             == bar(3)
             == foo(2, 3)
             == 5)
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
-    print(output)
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `foo()`
     assert output.endswith('foo')
     line, = (line for line in output.splitlines() if line.endswith('x + y'))
@@ -452,10 +445,7 @@ def test_property_decorator():
     obj.foo = 10  # Use setter
     assert obj.x == 5
     assert obj.foo == 10  # Use getter
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
-    print(output)
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `Object.foo`
     assert output.endswith('foo')
     getter_line, = (line for line in output.splitlines()
@@ -495,9 +485,7 @@ def test_cached_property_decorator():
     obj = Object(3)
     assert obj.foo == 6  # Use getter
     assert obj.foo == 6  # Getter not called because it's cached
-    with io.StringIO() as sio:
-        profile.print_stats(stream=sio, summarize=True)
-        output = strip(sio.getvalue())
+    output = strip(get_prof_stats(profile, name='profile', summarize=True))
     # Check that we have profiled `Object.foo`
     assert output.endswith('foo')
     line, = (line for line in output.splitlines() if line.endswith('* 2'))
@@ -611,10 +599,7 @@ def test_profile_generated_code():
     profiled_fn = profiler(fn)
     profiled_fn()
 
-    import io
-    s = io.StringIO()
-    profiler.print_stats(stream=s)
-    output = s.getvalue()
+    output = get_prof_stats(profiler, 'profiler')
 
     # Check that the output contains the generated code's source lines
     for line in code_lines:
@@ -798,13 +783,13 @@ def test_multiple_profilers_identical_bytecode(
 
     if force_same_line_numbers:
         funcs = {}
-        pattern = textwrap.dedent("""
+        pattern = strip("""
         def func{0}():
             result = []
             for _ in range({0}):
                 result.append({0})
             return result
-            """).strip('\n')
+            """)
         for i in [1, 2, 3, 4]:
             tempfile = tmp_path / f'func{i}.py'
             source = pattern.format(i)
@@ -862,11 +847,41 @@ def test_multiple_profilers_identical_bytecode(
                 for func in profiled_funcs}) == len(profiled_funcs)
     # Check the profiling results
     for name, prof in sorted(all_profs.items()):
-        with io.StringIO() as sio:
-            prof.print_stats(sio, summarize=True)
-            output = sio.getvalue()
-            print(f'@{name}:', textwrap.indent(output, '  '), sep='\n\n')
+        output = get_prof_stats(prof, name=name, summarize=True)
         for func_id, decs in all_dec_names.items():
             profiled = name in decs
             check_seen(name, output, func_id, profiled)
             check_has_profiling_data(name, output, func_id, profiled)
+
+
+def test_aggregate_profiling_data_between_code_versions():
+    """
+    Test that profiling data from previous versions of the code object
+    are preserved when another profiler causes the code object of a
+    function to be overwritten.
+    """
+    def func(n):
+        x = 0
+        for n in range(1, n + 1):
+            x += n
+        return x
+
+    prof1 = LineProfiler()
+    prof2 = LineProfiler()
+
+    # Gather data with `@prof1`
+    wrapper1 = prof1(func)
+    assert wrapper1(10) == 10 * 11 // 2
+    code = func.__code__
+    # Gather data with `@prof2`; the code object is overwritten here
+    wrapper2 = prof2(wrapper1)
+    assert func.__code__ != code
+    assert wrapper2(15) == 15 * 16 // 2
+    # Despite the overwrite of the code object, the old data should
+    # still remain, and be aggregated with the new data when calling
+    # `prof1.get_stats()`
+    for prof, name, count in (prof1, 'prof1', 25), (prof2, 'prof2', 15):
+        result = get_prof_stats(prof, name)
+        loop_body = next(line for line in result.splitlines()
+                         if line.endswith('x += n'))
+        assert loop_body.split()[1] == str(count)

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -713,3 +713,155 @@ def test_duplicate_code_objects():
     # (Entries are represented as tuples `(lineno, nhits, time)`)
     entries, = profile.get_stats().timings.values()
     assert entries[-2][1] == 10 + 20
+
+
+@pytest.mark.parametrize('force_same_line_numbers', [True, False])
+@pytest.mark.parametrize(
+    'ops',
+    [
+        # Replication of the problematic case in issue #350
+        'func1:prof_all'
+        '-func2:prof_some:prof_all'
+        '-func3:prof_all'
+        '-func4:prof_some:prof_all',
+        # Invert the order of decoration
+        'func1:prof_all'
+        '-func2:prof_all:prof_some'
+        '-func3:prof_all'
+        '-func4:prof_all:prof_some',
+        # More profiler stacks
+        'func1:p1:p2'
+        '-func2:p2:p3'
+        '-func3:p3:p4'
+        '-func4:p4:p1',
+        'func1:p1:p2:p3'
+        '-func2:p2:p3:p4'
+        '-func3:p3:p4:p1'
+        '-func4:p4:p1:p2',
+        'func1:p1:p2:p3'
+        '-func2:p4:p3:p2'
+        '-func3:p3:p4:p1'
+        '-func4:p2:p1:p4',
+        # Misc. edge cases
+        # - Note: while the following results in `func1()` and `func2()`
+        #   sharing the same bytecodes, the profiler `p3` is nonetheless
+        #   able to distinguish between the two (when the functions have
+        #   distinct line numbers), because they are defined on
+        #   different lines and thus hashed to different line hashes
+        'func1:p1:p2'  # `func1()` padded once
+        '-func2:p3'  # `func2()` padded twice
+        '-func1:p4:p3',  # `func1()` padded once (again)
+    ])
+def test_multiple_profilers_identical_bytecode(
+        tmp_path, ops, force_same_line_numbers):
+    """
+    Test that functions compiling down to the same bytecode are
+    correctly handled between multiple profilers.
+
+    Notes
+    -----
+    `ops` should consist of chunks joined by hyphens, where each chunk
+    has the format `<func_id>:<prof_name>[:<prof_name>[...]]`,
+    indicating that the profilers are to be used in order to decorate
+    the specified function.
+    """
+    def check_seen(name, output, func_id, expected):
+        lines = [line for line in output.splitlines()
+                 if line.startswith('Function: ')]
+        if any(func_id in line for line in lines) == expected:
+            return
+        if expected:
+            raise AssertionError(
+                f'profiler `@{name}` didn\'t see `{func_id}()`')
+        raise AssertionError(
+            f'profiler `@{name}` saw `{func_id}()`')
+
+    def check_has_profiling_data(name, output, func_id, expected):
+        assert func_id.startswith('func')
+        nloops = func_id[len('func'):]
+        try:
+            line = next(line for line in output.splitlines()
+                        if line.endswith(f'result.append({nloops})'))
+        except StopIteration:
+            if expected:
+                raise AssertionError(
+                    f'profiler `@{name}` didn\'t see `{func_id}()`')
+            else:
+                return
+        if (line.split()[1] == nloops) == expected:
+            return
+        if expected:
+            raise AssertionError(
+                f'profiler `@{name}` didn\'t get data from `{func_id}()`')
+        raise AssertionError(
+            f'profiler `@{name}` got data from `{func_id}()`')
+
+    if force_same_line_numbers:
+        funcs = {}
+        pattern = textwrap.dedent("""
+        def func{0}():
+            result = []
+            for _ in range({0}):
+                result.append({0})
+            return result
+            """).strip('\n')
+        for i in [1, 2, 3, 4]:
+            tempfile = tmp_path / f'func{i}.py'
+            source = pattern.format(i)
+            tempfile.write_text(source)
+            exec(compile(source, str(tempfile), 'exec'), funcs)
+    else:
+        def func1():
+            result = []
+            for _ in range(1):
+                result.append(1)
+            return result
+
+        def func2():
+            result = []
+            for _ in range(2):
+                result.append(2)
+            return result
+
+        def func3():
+            result = []
+            for _ in range(3):
+                result.append(3)
+            return result
+
+        def func4():
+            result = []
+            for _ in range(4):
+                result.append(4)
+            return result
+
+        funcs = {'func1': func1, 'func2': func2,
+                 'func3': func3, 'func4': func4}
+
+    # Apply the decorators in order
+    all_dec_names = {}
+    all_profs = {}
+    for op in ops.split('-'):
+        func_id, *profs = op.split(':')
+        all_dec_names.setdefault(func_id, set()).update(profs)
+        for name in profs:
+            try:
+                prof = all_profs[name]
+            except KeyError:
+                prof = all_profs[name] = LineProfiler()
+            funcs[func_id] = prof(funcs[func_id])
+    # Call each function once
+    assert funcs['func1']() == [1]
+    assert funcs['func2']() == [2, 2]
+    assert funcs['func3']() == [3, 3, 3]
+    assert funcs['func4']() == [4, 4, 4, 4]
+    # Check the profiling results
+    for name, prof in sorted(all_profs.items()):
+        with io.StringIO() as sio:
+            prof.print_stats(sio, summarize=True)
+            output = sio.getvalue()
+            print(f'@{name}:', textwrap.indent(output, '  '), sep='\n\n')
+        for func_id, decs in all_dec_names.items():
+            profiled = name in decs
+            check_seen(name, output, func_id, profiled)
+            check_has_profiling_data(name, output, func_id, profiled)

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -743,14 +743,12 @@ def test_duplicate_code_objects():
         '-func3:p3:p4:p1'
         '-func4:p2:p1:p4',
         # Misc. edge cases
-        # - Note: while the following results in `func1()` and `func2()`
-        #   sharing the same bytecodes, the profiler `p3` is nonetheless
-        #   able to distinguish between the two (when the functions have
-        #   distinct line numbers), because they are defined on
-        #   different lines and thus hashed to different line hashes
-        'func1:p1:p2'  # `func1()` padded once
-        '-func2:p3'  # `func2()` padded twice
-        '-func1:p4:p3',  # `func1()` padded once (again)
+        # - Naive padding of the following case would cause `func1()`
+        #   and `func2()` to end up with the same bytecode, so guard
+        #   against it
+        'func1:p1:p2'  # `func1()` padded once?
+        '-func2:p3'  # `func2()` padded twice?
+        '-func1:p4:p3',  # `func1()` padded once (again)?
     ])
 def test_multiple_profilers_identical_bytecode(
         tmp_path, ops, force_same_line_numbers):
@@ -760,10 +758,12 @@ def test_multiple_profilers_identical_bytecode(
 
     Notes
     -----
-    `ops` should consist of chunks joined by hyphens, where each chunk
-    has the format `<func_id>:<prof_name>[:<prof_name>[...]]`,
-    indicating that the profilers are to be used in order to decorate
-    the specified function.
+    - `ops` should consist of chunks joined by hyphens, where each chunk
+      has the format `<func_id>:<prof_name>[:<prof_name>[...]]`,
+      indicating that the profilers are to be used in order to decorate
+      the specified function.
+    - `force_same_line_numbers` is used to coerce all functions to
+      compile down to code objects with the same line numbers.
     """
     def check_seen(name, output, func_id, expected):
         lines = [line for line in output.splitlines()
@@ -839,11 +839,11 @@ def test_multiple_profilers_identical_bytecode(
                  'func3': func3, 'func4': func4}
 
     # Apply the decorators in order
-    all_dec_names = {}
+    all_dec_names = {f'func{i}': set() for i in [1, 2, 3, 4]}
     all_profs = {}
     for op in ops.split('-'):
         func_id, *profs = op.split(':')
-        all_dec_names.setdefault(func_id, set()).update(profs)
+        all_dec_names[func_id].update(profs)
         for name in profs:
             try:
                 prof = all_profs[name]
@@ -855,6 +855,11 @@ def test_multiple_profilers_identical_bytecode(
     assert funcs['func2']() == [2, 2]
     assert funcs['func3']() == [3, 3, 3]
     assert funcs['func4']() == [4, 4, 4, 4]
+    # Check that the bytecodes of the profiled functions are distinct
+    profiled_funcs = {funcs[name].__line_profiler_id__.func
+                      for name, decs in all_dec_names.items() if decs}
+    assert len({func.__code__.co_code
+                for func in profiled_funcs}) == len(profiled_funcs)
     # Check the profiling results
     for name, prof in sorted(all_profs.items()):
         with io.StringIO() as sio:


### PR DESCRIPTION
Closes #350. Includes #349, which by extension closes #348. New changes are from 7338799 onwards.

Code changes
----
- `line_profiler/_line_profiler.pyx::LineProfiler`
  - `.add_function()`
    - Now synchronizing the hash tables of instances profiling the same function object whenever it replaces its code object
    - No longer creating separate `.dupes_map` items for padded bytecodes
  - `._all_paddings`, `._all_instances_by_funcs`  
    New private class attributes for use by `.add_function()`

Test changes
----
- `tests/test_line_profiler.py`
  - `test_{{class,static,bound,partial}method,partial,[cached_]property}_decorator()`, `test_profile_generated_code()`  
    Minor refactoring with a utility function for more readable output
  - `test_multiple_profilers_identical_bytecode()`
    New test checking that the order in which profilers are used to decorate functions shouldn't affect the output (up to overhead)
  - `test_aggregate_profiling_data_between_code_versions()`  
    New test checking that existing profiling data should persist and be aggregated with new data after another profiler replaced the code object of a profiled function

Performance impact
----
Test suite run 5 times with the command `pytest 'not (test_duplicate or test_aggregate or identical_bytecode)'`, i.e. excluding the tests added by this PR (and #349); impact on performance should be minimal.

| Setup\Code (mean, best (s)) | `main` | `multi-desync-fix` (this PR) |
| :-: | :-: | :-: |
| Python 3.8.20, pytest 8.3.5 | 7.605, 7.518 | 7.523, 7.426 |
| Python 3.13.3, pytest 8.4.0 | 9.835, 9.589 | 9.777, 9.662 |