### PR TITLE
FIX: restore Cython compatibility + pivot to `sys.monitoring`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changes
   * On-import profiling is now more aggressive so that it doesn't miss entities
     like class methods and properties
   * ``LineProfiler`` can now be used as a class decorator
+* FIX: Fixed line tracing for Cython code; superseded use of the legacy tracing system with ``sys.monitoring``
 
 4.2.0
 ~~~~~

--- a/docs/source/auto/line_profiler.unset_trace.rst
+++ b/docs/source/auto/line_profiler.unset_trace.rst
@@ -1,8 +1,0 @@
-line\_profiler.unset\_trace module
-==================================
-
-.. automodule:: line_profiler.unset_trace
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :private-members:

--- a/line_profiler/CMakeLists.txt
+++ b/line_profiler/CMakeLists.txt
@@ -9,7 +9,6 @@ add_cython_target(${module_name} "${cython_source}" C OUTPUT_VAR sources)
 
 # Add any other non-cython dependencies to the sources
 list(APPEND sources
-  "${CMAKE_CURRENT_SOURCE_DIR}/unset_trace.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/timers.c"
 )
 message(STATUS "[OURS] sources = ${sources}")

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -336,11 +336,10 @@ cdef class LineProfiler:
                     PyCode_Addr2Line(<PyCodeObject*>code, offset))
                 code_hashes.append(code_hash)
         else:  # Cython functions
-            from linecache import getlines
-            from inspect import getblock
+            from line_profiler.line_profiler import get_code_block
 
             lineno = code.co_firstlineno
-            nlines = len(getblock(getlines(code.co_filename)[lineno - 1:]))
+            nlines = len(get_code_block(code.co_filename, lineno))
             block_hash = hash(code)
             for lineno in range(lineno, lineno + nlines):
                 code_hash = compute_line_hash(block_hash, lineno)

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -11,8 +11,7 @@ Ignore:
     # Assuming the cwd is the repo root.
     cythonize --annotate --inplace \
         ./line_profiler/_line_profiler.pyx \
-        ./line_profiler/timers.c \
-        ./line_profiler/unset_trace.c
+        ./line_profiler/timers.c
 """
 from .python25 cimport PyFrameObject, PyObject, PyStringObject
 from sys import byteorder
@@ -127,9 +126,6 @@ cdef extern from "Python.h":
 cdef extern from "timers.c":
     PY_LONG_LONG hpTimer()
     double hpTimerUnit()
-
-cdef extern from "unset_trace.c":
-    void unset_trace()
 
 cdef struct LineTime:
     int64 code
@@ -526,7 +522,7 @@ cdef class LineProfiler:
         elif CAN_USE_SYS_MONITORING:
             _sys_monitoring_deregister()
         else:
-            unset_trace()
+            PyEval_SetTrace(NULL, <object>NULL)
 
     def get_stats(self):
         """

--- a/line_profiler/profiler_mixin.py
+++ b/line_profiler/profiler_mixin.py
@@ -20,7 +20,10 @@ C_LEVEL_CALLABLE_TYPES = (types.BuiltinFunctionType,
                           types.MethodWrapperType,
                           types.WrapperDescriptorType)
 
-# Can't line-profile Cython in 3.12
+# Can't line-profile Cython in 3.12 since the old C API was upended
+# without an appropriate replacement (which only came in 3.13);
+# see also:
+# https://cython.readthedocs.io/en/latest/src/tutorial/profiling_tutorial.html
 _CANNOT_LINE_TRACE_CYTHON = (3, 12) <= version_info < (3, 13, 0, 'beta', 1)
 
 

--- a/line_profiler/profiler_mixin.pyi
+++ b/line_profiler/profiler_mixin.pyi
@@ -120,8 +120,7 @@ else:
 CLevelCallable = TypeVar('CLevelCallable',
                          BuiltinFunctionType, BuiltinMethodType,
                          ClassMethodDescriptorType, MethodDescriptorType,
-                         MethodWrapperType, WrapperDescriptorType,
-                         CythonCallable)
+                         MethodWrapperType, WrapperDescriptorType)
 
 
 def is_c_level_callable(func: Any) -> TypeIs[CLevelCallable]:

--- a/line_profiler/unset_trace.c
+++ b/line_profiler/unset_trace.c
@@ -1,7 +1,0 @@
-/* Hack to hide an <object>NULL from Cython. */
-
-#include "Python.h"
-
-void unset_trace() {
-    PyEval_SetTrace(NULL, NULL);
-}

--- a/line_profiler/unset_trace.h
+++ b/line_profiler/unset_trace.h
@@ -1,1 +1,0 @@
-void unset_trace();

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,8 @@ if __name__ == '__main__':
             return cythonize(
                 Extension(
                     name="line_profiler._line_profiler",
-                    sources=["line_profiler/_line_profiler.pyx", "line_profiler/timers.c", "line_profiler/unset_trace.c"],
+                    sources=["line_profiler/_line_profiler.pyx",
+                             "line_profiler/timers.c"],
                     language="c++",
                     define_macros=[("CYTHON_TRACE", (1 if os.getenv("DEV") == "true" else 0))],
                 ),

--- a/tests/cython_example/cython_example.pyx
+++ b/tests/cython_example/cython_example.pyx
@@ -1,0 +1,26 @@
+# cython: profile=True
+# cython: linetrace=True
+# distutils: define_macros=CYTHON_TRACE=1
+
+
+ctypedef long double Float
+
+
+def cos(Float x, int n):  # Start: cos
+    cdef Float neg_xsq = -x * x
+    cdef Float last_term = 1.
+    cdef Float result = 0.
+    for n in range(2, 2 * n, 2):
+        result += last_term
+        last_term *= neg_xsq / <Float>(n * (n - 1))
+    return result + last_term   # End: cos
+
+
+cpdef sin(Float x, int n):  # Start: sin
+    cdef Float neg_xsq = -x * x
+    cdef Float last_term = x
+    cdef Float result = 0.
+    for n in range(2, 2 * n, 2):
+        result += last_term
+        last_term *= neg_xsq / <Float>(n * (n + 1))
+    return result + last_term  # End: sin

--- a/tests/cython_example/pyproject.toml
+++ b/tests/cython_example/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "Cython"]
+
+[project]
+name = 'cython_example'
+description = 'Sample Cython module to be profiled'
+version = '0.0.0'

--- a/tests/cython_example/setup.py
+++ b/tests/cython_example/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+from Cython.Build import cythonize
+
+setup(ext_modules=cythonize('cython_example.pyx'))

--- a/tests/test_cython.py
+++ b/tests/test_cython.py
@@ -1,0 +1,132 @@
+"""
+Tests for profiling Cython code.
+"""
+import math
+import os
+import subprocess
+import sys
+from importlib import reload, import_module
+from importlib.util import find_spec
+from io import StringIO
+from operator import methodcaller
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import ModuleType
+from typing import Generator, Tuple
+from uuid import uuid4
+
+import pytest
+
+from line_profiler._line_profiler import (
+    CANNOT_LINE_TRACE_CYTHON, find_cython_source_file)
+from line_profiler.line_profiler import get_code_block, LineProfiler
+
+
+def propose_name(prefix: str) -> Generator[str, None, None]:
+    while True:
+        yield '_'.join([prefix, *str(uuid4()).split('-')])
+
+
+def _install_cython_example(
+        editable: bool) -> Generator[Tuple[Path, str], None, None]:
+    """
+    Install the example Cython module in a name-clash-free manner.
+    """
+    source = Path(__file__).parent / 'cython_example'
+    assert source.is_dir()
+    module = next(name for name in propose_name('cython_example')
+                  if not find_spec(name))
+    replace = methodcaller('replace', 'cython_example', module)
+    pip = [sys.executable, '-m', 'pip']
+    with TemporaryDirectory() as tmpdir:
+        # Replace all references to `cython_example` with the actual
+        # module name and write to the tempdir
+        tmp_path = Path(tmpdir)
+        for prefix, _, files in os.walk(source):
+            dir_in = Path(prefix)
+            for fname in files:
+                _, ext = os.path.splitext(fname)
+                if ext not in {'.py', '.pyx', '.pxd', '.toml'}:
+                    continue
+                dir_out = tmp_path.joinpath(*(
+                    replace(part)
+                    for part in dir_in.relative_to(source).parts))
+                dir_out.mkdir(exist_ok=True)
+                file_in = dir_in / fname
+                file_out = dir_out / replace(fname)
+                file_out.write_text(replace(file_in.read_text()))
+        # There should only be one Cython source file
+        cython_source, = tmp_path.glob('*.pyx')
+        pip_install = pip + ['install', '--verbose']
+        if editable:
+            pip_install += ['--editable', tmpdir]
+        else:
+            pip_install.append(tmpdir)
+        try:
+            subprocess.run(pip_install).check_returncode()
+            subprocess.run(pip + ['list']).check_returncode()
+            yield cython_source, module
+        finally:
+            pip_uninstall = pip + ['uninstall', '--verbose', '--yes', module]
+            subprocess.run(pip_uninstall).check_returncode()
+
+
+@pytest.fixture(scope='module')
+def cython_example() -> Tuple[Path, ModuleType]:
+    """
+    Install the example Cython module, yield the path to the Cython
+    source file and the corresponding module, uninstall it at teardown.
+    """
+    # With editable installs, we need to refresh `sys.meta_path` before
+    # the installed module is available
+    for path, mod_name in _install_cython_example(True):
+        reload(import_module('site'))
+        yield (path, import_module(mod_name))
+
+
+def test_recover_cython_source(cython_example: Tuple[Path, str]) -> None:
+    """
+    Check that Cython sources are correctly located by
+    `line_profiler._line_profiler.find_cython_source_file()` and
+    `line_profiler.line_profiler.get_code_block()`.
+    """
+    expected_source, module = cython_example
+    for func in module.cos, module.sin:
+        source = find_cython_source_file(func)
+        assert source
+        assert expected_source.samefile(source)
+        source_lines = get_code_block(source, func.__code__.co_firstlineno)
+        for line, prefix in [(source_lines[0], '# Start: '),
+                             (source_lines[-1], '# End: ')]:
+            assert line.rstrip('\n').endswith(prefix + func.__name__)
+
+
+@pytest.mark.skipif(
+    CANNOT_LINE_TRACE_CYTHON,
+    reason='Cannot line-trace Cython code in version '
+    + '.'.join(str(v) for v in sys.version_info[:3]))
+def test_profile_cython_source(cython_example: Tuple[Path, str]) -> None:
+    """
+    Check that calls to Cython functions (built with the appropriate
+    compile-time options) can be profiled.
+    """
+    prof_cos = LineProfiler()
+    prof_sin = LineProfiler()
+
+    cos = prof_cos(cython_example[1].cos)
+    sin = prof_sin(cython_example[1].sin)
+    assert pytest.approx(cos(.125, 10)) == math.cos(.125)
+    assert pytest.approx(sin(2.5, 3)) == 2.5 - 2.5 ** 3 / 6 + 2.5 ** 5 / 120
+
+    for prof, func, expected_nhits in [
+            (prof_cos, 'cos', 10), (prof_sin, 'sin', 3)]:
+        with StringIO() as fobj:
+            prof.print_stats(fobj)
+            result = fobj.getvalue()
+            print(result)
+        assert ('Function: ' + func) in result
+        nhits = 0
+        for line in result.splitlines():
+            if all(chunk in line for chunk in ('result', '+', 'last_term')):
+                nhits += int(line.split()[1])
+        assert nhits == expected_nhits

--- a/tests/test_cython.py
+++ b/tests/test_cython.py
@@ -10,7 +10,6 @@ from importlib.util import find_spec
 from io import StringIO
 from operator import methodcaller
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from types import ModuleType
 from typing import Generator, Tuple
 from uuid import uuid4
@@ -28,6 +27,7 @@ def propose_name(prefix: str) -> Generator[str, None, None]:
 
 
 def _install_cython_example(
+        tmp_path_factory: pytest.TempPathFactory,
         editable: bool) -> Generator[Tuple[Path, str], None, None]:
     """
     Install the example Cython module in a name-clash-free manner.
@@ -38,48 +38,47 @@ def _install_cython_example(
                   if not find_spec(name))
     replace = methodcaller('replace', 'cython_example', module)
     pip = [sys.executable, '-m', 'pip']
-    with TemporaryDirectory() as tmpdir:
-        # Replace all references to `cython_example` with the actual
-        # module name and write to the tempdir
-        tmp_path = Path(tmpdir)
-        for prefix, _, files in os.walk(source):
-            dir_in = Path(prefix)
-            for fname in files:
-                _, ext = os.path.splitext(fname)
-                if ext not in {'.py', '.pyx', '.pxd', '.toml'}:
-                    continue
-                dir_out = tmp_path.joinpath(*(
-                    replace(part)
-                    for part in dir_in.relative_to(source).parts))
-                dir_out.mkdir(exist_ok=True)
-                file_in = dir_in / fname
-                file_out = dir_out / replace(fname)
-                file_out.write_text(replace(file_in.read_text()))
-        # There should only be one Cython source file
-        cython_source, = tmp_path.glob('*.pyx')
-        pip_install = pip + ['install', '--verbose']
-        if editable:
-            pip_install += ['--editable', tmpdir]
-        else:
-            pip_install.append(tmpdir)
-        try:
-            subprocess.run(pip_install).check_returncode()
-            subprocess.run(pip + ['list']).check_returncode()
-            yield cython_source, module
-        finally:
-            pip_uninstall = pip + ['uninstall', '--verbose', '--yes', module]
-            subprocess.run(pip_uninstall).check_returncode()
+    tmp_path = tmp_path_factory.mktemp('cython_example')
+    # Replace all references to `cython_example` with the actual module
+    # name and write to the tempdir
+    for prefix, _, files in os.walk(source):
+        dir_in = Path(prefix)
+        for fname in files:
+            _, ext = os.path.splitext(fname)
+            if ext not in {'.py', '.pyx', '.pxd', '.toml'}:
+                continue
+            dir_out = tmp_path.joinpath(*(
+                replace(part) for part in dir_in.relative_to(source).parts))
+            dir_out.mkdir(exist_ok=True)
+            file_in = dir_in / fname
+            file_out = dir_out / replace(fname)
+            file_out.write_text(replace(file_in.read_text()))
+    # There should only be one Cython source file
+    cython_source, = tmp_path.glob('*.pyx')
+    pip_install = pip + ['install', '--verbose']
+    if editable:
+        pip_install += ['--editable', str(tmp_path)]
+    else:
+        pip_install.append(str(tmp_path))
+    try:
+        subprocess.run(pip_install).check_returncode()
+        subprocess.run(pip + ['list']).check_returncode()
+        yield cython_source, module
+    finally:
+        pip_uninstall = pip + ['uninstall', '--verbose', '--yes', module]
+        subprocess.run(pip_uninstall).check_returncode()
 
 
 @pytest.fixture(scope='module')
-def cython_example() -> Tuple[Path, ModuleType]:
+def cython_example(
+        tmp_path_factory: pytest.TempPathFactory) -> Tuple[Path, ModuleType]:
     """
     Install the example Cython module, yield the path to the Cython
     source file and the corresponding module, uninstall it at teardown.
     """
     # With editable installs, we need to refresh `sys.meta_path` before
     # the installed module is available
-    for path, mod_name in _install_cython_example(True):
+    for path, mod_name in _install_cython_example(tmp_path_factory, True):
         reload(import_module('site'))
         yield (path, import_module(mod_name))
 

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -587,12 +587,10 @@ def test_add_class_wrapper():
 @pytest.mark.parametrize('decorate', [True, False])
 def test_profiler_c_callable_no_op(decorate):
     """
-    Test that the following are no-ops on C(-ython)-level callables:
+    Test that the following are no-ops on C-level callables:
     - Decoration (`.__call__()`): the callable is returned as-is.
     - `.add_callable()`: it returns 0.
     """
-    CythonCallable = type(LineProfiler.enable)
-    assert not isinstance(LineProfiler.enable, types.FunctionType)
     profile = LineProfiler()
 
     for (func, Type) in [
@@ -601,8 +599,7 @@ def test_profiler_c_callable_no_op(decorate):
             (vars(int)['from_bytes'], types.ClassMethodDescriptorType),
             (str.split, types.MethodDescriptorType),
             ((1).__str__, types.MethodWrapperType),
-            (int.__repr__, types.WrapperDescriptorType),
-            (LineProfiler.enable, CythonCallable)]:
+            (int.__repr__, types.WrapperDescriptorType)]:
         assert isinstance(func, Type)
         if decorate:  # Decoration is no-op
             assert profile(func) is func


### PR DESCRIPTION
(May close #200. Related: cython/cython#3929, cython/cython#5140)

Synopsis
----
This PR fixes line-profiling for Cython code (which has been broken since the 4.0 version bump) by using an alternative source for code hashes with Cython functions. To that effect, we also switch to using `sys.monitoring` callbacks instead of the "legacy" tracing system where available (Python 3.12+), making it possible to line-profile Cython code in Python 3.13+.[^1]

Motivations
----
- It bugged me that we've made all these advancements in `line_profiler` and yet the `cython` folks were forced to [pin the version to 3](https://github.com/cython/cython/pull/5140), and it seemed like there are no good reasons that we shouldn't be able to support that with minimal overhead.
- Since Python 3.12 the existing tracing system has been [referred to as "legacy"](https://github.com/python/cpython/blob/main/Python/legacy_tracing.c), and largely to be superseded in usage by `sys.monitoring`. While Python probably won't drop support for the old way any time soon, future versions are likely to focus on optimizing `sys.monitoring` at the expense of the old system.
- As the ecosystem evolves, other tools' support for the old tracing system is also likely to wane. Case in point: since Python 3.13 Cython has switched to the new API, leading to old-style trace functions no longer receiving line events therefrom.  

Performance impacts
----
Tests are run comparing the [`eager-prof-mod`](https://github.com/TTsangSC/line_profiler/tree/eager-prof-mod) branch (#337) and this PR, excluding the new tests with `-k "not cython"`.

| Python version\\PR (min/mean time (s; of 5)) | #337 | This PR |
| :-: | :-: | :-: |
| 3.8 | 11.51/11.67 | 11.50/11.60 |
| 3.11 | 11.76/11.91 | 11.90/12.00 |
| 3.12 | 12.98/13.16 | 12.99/13.11 |
| 3.13 | 14.39/14.72 | 13.92/14.25 |

Code changes
----
~~(This PR is based on #337, which is slated to be merged soon-ish. New changes are from f225f93 onwards.)~~

- `line_profiler/_line_profiler.pyx`
  - `_sys_monitoring_[de]register()`:
    - No longer defined in Python < 3.12
    - Now used for setting up/tearing down the `sys.monitoring` hooks
  - `get_frame_code()`:  
    Now returning the code object instead of its `.co_code`
  - `find_cython_source_file()`:  
    New function for resolving the source-file location of Cython functions (because [`.__code__.co_filename` is only relative](https://github.com/cython/cython/pull/3929) and does not generally work)
  - `LineProfiler`:
    - `add_function()`:  
      Added handling for creating line hashes for Cython-function code objects, which:
      - Cannot be replaced
      - Do not contain the absolute path to the Cython source file, and
      - Only have empty or all-null-byte bytecodes
    - `enable()`, `disable()`:  
      - Now only using the "legacy" tracing system if `sys.monitoring` is not available
      - **(Update 7 Jul)**: inlined call to `PyEval_SetTrace(NULL, NULL)` for disabling legacy tracing
  - `inner_trace_callback()`:
    - Refactored from the body of previous `python_trace_callback()`
    - Added handling for computing line hashes for Cython-function code objects
  - `monitoring_line_event_callback()`, `monitoring_exit_frame_callback()`:  
    New callbacks for use with `sys.monitoring.register_callback()`
  - `legacy_trace_callback()`:  
    Supersedes the previous `python_trace_callback()`
- `line_profiler/line_profiler.py`
  - `get_code_block()`:  
    - New wrapper function around `inspect.getblock()` to facilitate the handling of Cython source
    - **(Updated 7 Jul)**: added doctest
- `line_profiler/profiler_mixin.py[i]`
  - `is_c_level_callable()`  
    No longer returning `True` for Cython callables
  - `ByCountProfilerMixin.get_underlying_functions()`  
    Now returning Cython functions for compatible (i.e. not 3.12) Python versions

Test changes
----
- `tests/cython_example/`
  New, small, installable, line-traceable Cython project
- `tests/test_cython.py`[^2]  
  New test module for Cython-related stuff:
  - `test_recover_cython_source()`  
    Test for the retrieval and parsing of Cython sources
  - `test_profile_cython_source()`  
    Test for the line-profiling of Cython code

Possible conflicts
----
Other PRs which touches the Cython code like #334, #349, and #351.

[^1]: Note that as acknowledged in the [Cython docs](https://cython.readthedocs.io/en/latest/src/tutorial/profiling_tutorial.html) line-tracing (and thus profiling) fundamentally doesn't work on Python 3.12, since the old C API was changed without an appropriate replacement, which was only [added in 3.13](https://docs.python.org/3/c-api/monitoring.html#c-api-monitoring).
[^2]: These tests are rather slow (≈ 5–6 s combined) due to their use of a module-scoped fixture which temporarily installs the `tests/cython_example/` project. Maybe we should mark it (and certain bigger tests) with a marker and only run it for say half of the matrix?