### PR TITLE
Post-337 patches: docs, fixes, minor refactoring

### DIFF
--- a/docs/source/auto/kernprof.rst
+++ b/docs/source/auto/kernprof.rst
@@ -7,4 +7,3 @@ kernprof module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.__main__.rst
+++ b/docs/source/auto/line_profiler.__main__.rst
@@ -5,4 +5,3 @@ line\_profiler.\_\_main\_\_ module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler._line_profiler.rst
+++ b/docs/source/auto/line_profiler._line_profiler.rst
@@ -5,4 +5,3 @@ line\_profiler.\_line\_profiler module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.ast_profile_transformer.rst
+++ b/docs/source/auto/line_profiler.autoprofile.ast_profile_transformer.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.ast\_profle\_transformer module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.ast_tree_profiler.rst
+++ b/docs/source/auto/line_profiler.autoprofile.ast_tree_profiler.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.ast\_tree\_profiler module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.autoprofile.rst
+++ b/docs/source/auto/line_profiler.autoprofile.autoprofile.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.autoprofile module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.eager_preimports.rst
+++ b/docs/source/auto/line_profiler.autoprofile.eager_preimports.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.eager\_preimports module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.line_profiler_utils.rst
+++ b/docs/source/auto/line_profiler.autoprofile.line_profiler_utils.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.line\_profiler\_utils module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.profmod_extractor.rst
+++ b/docs/source/auto/line_profiler.autoprofile.profmod_extractor.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.profmod\_extractor module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.rst
+++ b/docs/source/auto/line_profiler.autoprofile.rst
@@ -23,4 +23,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.run_module.rst
+++ b/docs/source/auto/line_profiler.autoprofile.run_module.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.run\_module module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.autoprofile.util_static.rst
+++ b/docs/source/auto/line_profiler.autoprofile.util_static.rst
@@ -5,4 +5,3 @@ line\_profiler.autoprofile.util\_static module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.explicit_profiler.rst
+++ b/docs/source/auto/line_profiler.explicit_profiler.rst
@@ -5,4 +5,3 @@ line\_profiler.explicit\_profiler module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.ipython_extension.rst
+++ b/docs/source/auto/line_profiler.ipython_extension.rst
@@ -5,4 +5,3 @@ line\_profiler.ipython\_extension module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.line_profiler.rst
+++ b/docs/source/auto/line_profiler.line_profiler.rst
@@ -5,4 +5,3 @@ line\_profiler.line\_profiler module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.profiler_mixin.rst
+++ b/docs/source/auto/line_profiler.profiler_mixin.rst
@@ -5,4 +5,3 @@ line\_profiler.profiler\_mixin module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.rst
+++ b/docs/source/auto/line_profiler.rst
@@ -30,4 +30,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.scoping_policy.rst
+++ b/docs/source/auto/line_profiler.scoping_policy.rst
@@ -5,4 +5,3 @@ line\_profiler.scoping\_policy module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.timers.rst
+++ b/docs/source/auto/line_profiler.timers.rst
@@ -5,4 +5,3 @@ line\_profiler.timers module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/docs/source/auto/line_profiler.unset_trace.rst
+++ b/docs/source/auto/line_profiler.unset_trace.rst
@@ -5,4 +5,3 @@ line\_profiler.unset\_trace module
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:

--- a/kernprof.py
+++ b/kernprof.py
@@ -903,7 +903,12 @@ def _dump_filtered_stats(tmpdir, prof, filename):
         for fname in fnames
     ]
 
-    if not tempfile_paths:
+    if not tempfile_paths or isinstance(prof, ContextualProfile):
+        # - No tempfiles written -> no function lives in tempfiles
+        #   -> no need to filter anything
+        # - Not using `line_profiler`
+        #   -> doesn't matter if the source lines can't be retrieved
+        #   -> no need to filter anything
         prof.dump_stats(filename)
         return
 

--- a/kernprof.py
+++ b/kernprof.py
@@ -706,7 +706,7 @@ def main(args=None):
         diagnostics.log.debug(
             f'Profiling script read from: {tempfile_source_and_content[0]}')
     else:
-        diagnostics.log.debug(f'Profiling script: {options.script}')
+        diagnostics.log.debug(f'Profiling script: {options.script!r}')
 
     with contextlib.ExitStack() as stack:
         enter = stack.enter_context
@@ -869,8 +869,7 @@ def _write_preimports(prof, options, exclude):
         with temp_file as fobj:
             print(code, file=fobj)
         diagnostics.log.debug(
-            'Wrote temporary module for pre-imports '
-            f'to {temp_mod_path!r}:')
+            f'Wrote temporary module for pre-imports to {temp_mod_path!r}')
     else:
         with temp_file as fobj:
             write_eager_import_module(stream=fobj, **write_module_kwargs)

--- a/kernprof.py
+++ b/kernprof.py
@@ -1064,36 +1064,33 @@ def _main_profile(options, module=False):
     """
     script_file, prof = _pre_profile(options, module)
     try:
-        try:
-            rmod = functools.partial(run_module,
-                                     run_name='__main__', alter_sys=True)
-            ns = {'__file__': script_file, '__name__': '__main__',
-                  'execfile': execfile, 'rmod': rmod,
-                  'prof': prof}
-            if options.prof_mod and options.line_by_line:
-                from line_profiler.autoprofile import autoprofile
-                _call_with_diagnostics(
-                    options,
-                    autoprofile.run, script_file, ns,
-                    prof_mod=options.prof_mod,
-                    profile_imports=options.prof_imports,
-                    as_module=module is not None)
-            elif module and options.builtin:
-                _call_with_diagnostics(options, rmod, options.script, ns)
-            elif options.builtin:
-                _call_with_diagnostics(options, execfile, script_file, ns, ns)
-            elif module:
-                _call_with_diagnostics(
-                    options,
-                    prof.runctx, f'rmod({options.script!r}, globals())',
-                    ns, ns)
-            else:
-                _call_with_diagnostics(
-                    options,
-                    prof.runctx, f'execfile({script_file!r}, globals())',
-                    ns, ns)
-        except (KeyboardInterrupt, SystemExit):
-            pass
+        rmod = functools.partial(run_module,
+                                 run_name='__main__', alter_sys=True)
+        ns = {'__file__': script_file, '__name__': '__main__',
+              'execfile': execfile, 'rmod': rmod,
+              'prof': prof}
+        if options.prof_mod and options.line_by_line:
+            from line_profiler.autoprofile import autoprofile
+            _call_with_diagnostics(
+                options,
+                autoprofile.run, script_file, ns,
+                prof_mod=options.prof_mod,
+                profile_imports=options.prof_imports,
+                as_module=module is not None)
+        elif module and options.builtin:
+            _call_with_diagnostics(options, rmod, options.script, ns)
+        elif options.builtin:
+            _call_with_diagnostics(options, execfile, script_file, ns, ns)
+        elif module:
+            _call_with_diagnostics(
+                options,
+                prof.runctx, f'rmod({options.script!r}, globals())',
+                ns, ns)
+        else:
+            _call_with_diagnostics(
+                options,
+                prof.runctx, f'execfile({script_file!r}, globals())',
+                ns, ns)
     finally:
         _post_profile(options, prof)
 

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -183,10 +183,8 @@ def test_kernprof_sys_restoration(capsys, error, args):
     [('',  # Neutral verbosity level
       {'^Output to stdout': True,
        r"^Wrote .* '.*script\.py\.lprof'": True,
-       r'Parser output:''(?:\n)+'r'.*namespace\((?:.+,\n)*.*\)': False,
        r'^Inspect results with:''\n'
        r'python -m line_profiler .*script\.py\.lprof': True,
-       '^ *[0-9]+ *import zipfile': False,
        r'line_profiler\.autoprofile\.autoprofile'
        r'\.run\(\n(?:.+,\n)*.*\)': False,
        r'^\[kernprof .*\]': False,


### PR DESCRIPTION
Miscellaneous stuff that was discussed during #337 but didn't make the cut before the merge.

- `docs/**/*.rst`:  
  Removed the `:private-members:` directive so that we don't give mixed signals as to what is in the public(-ly documented) API
- `kernprof.py`
  - `main()`, `_write_preimports()`:  
    Minor formatting fixes for stdout/logging output
  - `_dump_filtered_stats()`:  
    Fixed error (by early-exiting) because `kernprof.ContextualProfile` is incompatible with (and doesn't need) the filtering of profiling results
  - `_main_profile()`:  
    Unnested redundant `try` block, and stopped suppressing `BaseException`s (since the profiling output is written anyway)
- `line_profiler/profiler_mixin.py::ByCountProfilerMixin`
  - `_get_underlying_functions()`:
    - Refactored section handling classes and properties into separate methods to reduce complexity
    - Refactored away use of `functools.partial` where possible
    - Added clarifying comments
  - `wrap_class()`:  
    Refactored away use of `functools.partial` where possible
- `tests/test_kernprof.py::test_kernprof_verbosity()`:  
  Scrubbed remnant of tests for code output (removed in 447ab0a to 1b88d97)