### PR TITLE
FIX: missing line events for `raise` statements and `finally: ...` bodies in Python 3.12+

### DIFF
--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -191,7 +191,9 @@ if CAN_USE_SYS_MONITORING:
         events = (mon.get_events(mon.PROFILER_ID)
                   | mon.events.LINE
                   | mon.events.PY_RETURN
-                  | mon.events.PY_YIELD)
+                  | mon.events.PY_YIELD
+                  | mon.events.RAISE
+                  | mon.events.RERAISE)
         mon.set_events(mon.PROFILER_ID, events)
         # TODO: store and/or call previous callbacks, see #334
         line_callback = functools.partial(
@@ -203,6 +205,10 @@ if CAN_USE_SYS_MONITORING:
             mon.PROFILER_ID, mon.events.PY_RETURN, exit_callback)
         mon.register_callback(
             mon.PROFILER_ID, mon.events.PY_YIELD, exit_callback)
+        mon.register_callback(
+            mon.PROFILER_ID, mon.events.RAISE, exit_callback)
+        mon.register_callback(
+            mon.PROFILER_ID, mon.events.RERAISE, exit_callback)
 
     def _sys_monitoring_deregister() -> None:
         if not _is_main_thread():
@@ -212,6 +218,8 @@ if CAN_USE_SYS_MONITORING:
         mon.register_callback(mon.PROFILER_ID, mon.events.LINE, None)
         mon.register_callback(mon.PROFILER_ID, mon.events.PY_RETURN, None)
         mon.register_callback(mon.PROFILER_ID, mon.events.PY_YIELD, None)
+        mon.register_callback(mon.PROFILER_ID, mon.events.RAISE, None)
+        mon.register_callback(mon.PROFILER_ID, mon.events.RERAISE, None)
 
 
 def label(code):

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -1028,12 +1028,19 @@ def test_aggregate_profiling_data_between_code_versions():
         assert loop_body.split()[1] == str(count)
 
 
+@pytest.mark.xfail(condition=sys.version_info[:2] == (3, 9),
+                   reason='Handling of `finally` bugged in Python 3.9')
 def test_profiling_exception():
     """
     Test that profiling data is reported for:
     - The line raising an exception
     - The last lines in the `except` and `finally` subblocks of a
       `try`-(`except`-)`finally` statement
+
+    Notes
+    -----
+    Seems to be bugged for Python 3.9 only; may be related to CPython
+    issue #83295.
     """
     prof = LineProfiler()
 


### PR DESCRIPTION
(Closes #355.)

Changes
----
- `line_profiler/_line_profiler.pyx`  
  Added handling for `sys.monitoring.events.RAISE` and `.RERAISE`
- `tests/test_line_profiler.py::test_profiling_exception()`  
  New test for checking whether `raise` statements and `finally: ...`
    bodies are properly profiled

Caveats
----
- The new test X-Fails in Python 3.9 because exit data is missing for the `finally` body in a `try: ... except: ... finally: ...` block where the exception is re-raised (see e.g. [action `#1005`](https://github.com/pyutils/line_profiler/actions/runs/16326762849/job/46118806758)). The exact reason for the failure is unclear, but I suspect it has to do with python/cpython#83295. 