### PR TITLE
FIX: tempdir-leaking tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,24 +141,24 @@ def test_cli():
         if __name__ == '__main__':
             my_inefficient_function()
         ''')
-    tmp_dpath = tempfile.mkdtemp()
-    tmp_src_fpath = join(tmp_dpath, 'foo.py')
-    with open(tmp_src_fpath, 'w') as file:
-        file.write(code)
+    with tempfile.TemporaryDirectory() as tmp_dpath:
+        tmp_src_fpath = join(tmp_dpath, 'foo.py')
+        with open(tmp_src_fpath, 'w') as file:
+            file.write(code)
 
-    # Run kernprof on it
-    info = ub.cmd(f'kernprof -l {tmp_src_fpath}', verbose=3, cwd=tmp_dpath)
-    assert info['ret'] == 0
+        # Run kernprof on it
+        info = ub.cmd(f'kernprof -l {tmp_src_fpath}', verbose=3, cwd=tmp_dpath)
+        assert info['ret'] == 0
 
-    tmp_lprof_fpath = join(tmp_dpath, 'foo.py.lprof')
-    tmp_lprof_fpath
+        tmp_lprof_fpath = join(tmp_dpath, 'foo.py.lprof')
+        tmp_lprof_fpath
 
-    info = ub.cmd(f'{executable} -m line_profiler {tmp_lprof_fpath}',
-                  cwd=tmp_dpath, verbose=3)
-    assert info['ret'] == 0
-    # Check for some patterns that should be in the output
-    assert '% Time' in info['out']
-    assert '7       100' in info['out']
+        info = ub.cmd(f'{executable} -m line_profiler {tmp_lprof_fpath}',
+                      cwd=tmp_dpath, verbose=3)
+        assert info['ret'] == 0
+        # Check for some patterns that should be in the output
+        assert '% Time' in info['out']
+        assert '7       100' in info['out']
 
 
 def test_version_agreement():

--- a/tests/test_complex_case.py
+++ b/tests/test_complex_case.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+from contextlib import ExitStack
 import ubelt as ub
 LINUX = sys.platform.startswith('linux')
 
@@ -90,8 +91,9 @@ def test_varied_complex_invocations():
     results = []
 
     for case in cases:
-        temp_dpath = tempfile.mkdtemp()
-        with ub.ChDir(temp_dpath):
+        with ExitStack() as stack:
+            temp_dpath = stack.enter_context(tempfile.TemporaryDirectory())
+            stack.enter_context(ub.ChDir(temp_dpath))
             env = {}
 
             outpath = case['outpath']


### PR DESCRIPTION
Replaced use of `tempfile.mkdtemp()` with the `tempfile.TemporaryDirectory()` context manager in the following tests:
- `tests/test_cli.py::test_cli()`
- `tests/test_complex_case.py::test_varied_complex_invocations()`

This removes the 12 tempdirs that erroneously persist after each `pytest` run.