### PR TITLE
FIX: stubs and `ConfigSource` doc

### DIFF
--- a/line_profiler/autoprofile/line_profiler_utils.pyi
+++ b/line_profiler/autoprofile/line_profiler_utils.pyi
@@ -1,25 +1,29 @@
-from types import ModuleType
-from typing import overload, Any, Literal, TYPE_CHECKING
+from functools import partial, partialmethod, cached_property
+from types import FunctionType, MethodType, ModuleType
+from typing import overload, Any, Literal, TypeVar, TYPE_CHECKING
 
 if TYPE_CHECKING:  # Stub-only annotations
-    from ..line_profiler import CallableLike
-    from ..profiler_mixin import CLevelCallable
+    from ..profiler_mixin import CLevelCallable, CythonCallable
     from ..scoping_policy import ScopingPolicy, ScopingPolicyDict
+
+
 
 
 @overload
 def add_imported_function_or_module(
         self, item: CLevelCallable | Any,
-        scoping_policy: (
-            ScopingPolicy | str | ScopingPolicyDict | None) = None,
+        scoping_policy: ScopingPolicy | str | ScopingPolicyDict | None = None,
         wrap: bool = False) -> Literal[0]:
     ...
 
 
 @overload
 def add_imported_function_or_module(
-        self, item: CallableLike | ModuleType,
-        scoping_policy: (
-            ScopingPolicy | str | ScopingPolicyDict | None) = None,
+        self,
+        item: (FunctionType | CythonCallable
+               | type | partial | property | cached_property
+               | MethodType | staticmethod | classmethod | partialmethod
+               | ModuleType),
+        scoping_policy: ScopingPolicy | str | ScopingPolicyDict | None = None,
         wrap: bool = False) -> Literal[0, 1]:
     ...

--- a/line_profiler/cli_utils.py
+++ b/line_profiler/cli_utils.py
@@ -219,7 +219,7 @@ def boolean(value, *, fallback=None, invert=False):
     Arguments:
         value (str)
             Value to be parsed into a boolean (case insensitive)
-        fallback (Union[bool, None])
+        fallback (bool | None)
             Optional value to fall back to in case ``value`` doesn't
             match any of the specified
         invert (bool)
@@ -278,12 +278,12 @@ def boolean(value, *, fallback=None, invert=False):
 def short_string_path(path):
     """
     Arguments:
-        path (Union[str, PurePath]):
+        path (str | os.PathLike[str]):
             Path-like
 
     Returns:
         str: short_path
-            The shortest formatted ``path`` among the provided path, the
+            The shortest formatted path among the provided ``path``, the
             corresponding absolute path, and its relative path to the
             current directory.
     """

--- a/line_profiler/cli_utils.pyi
+++ b/line_profiler/cli_utils.pyi
@@ -4,19 +4,21 @@ Shared utilities between the :command:`python -m line_profiler` and
 """
 import argparse
 import pathlib
-from typing import Protocol, Sequence, Tuple, TypeVar, Union
+from os import PathLike
+from typing import Protocol, Sequence, Tuple, TypeVar
 
 from line_profiler.toml_config import ConfigSource
 
 
+P_con = TypeVar('P_con', bound='ParserLike', contravariant=True)
 A_co = TypeVar('A_co', bound='ActionLike', covariant=True)
 
 
-class ActionLike(Protocol):
-    def __call__(self, parser: 'ParserLike',
+class ActionLike(Protocol[P_con]):
+    def __call__(self, parser: P_con,
                  namespace: argparse.Namespace,
-                 values: Sequence,
-                 option_string: Union[str, None] = None) -> None:
+                 values: str | Sequence | None,
+                 option_string: str | None = None) -> None:
         ...
 
     def format_usage(self) -> str:
@@ -50,9 +52,9 @@ def positive_float(value: str) -> float:
 
 
 def boolean(value: str, *,
-            fallback: Union[bool, None] = None, invert: bool = False) -> bool:
+            fallback: bool | None = None, invert: bool = False) -> bool:
     ...
 
 
-def short_string_path(path: Union[str, pathlib.PurePath]) -> str:
+def short_string_path(path: str | PathLike[str]) -> str:
     ...

--- a/line_profiler/scoping_policy.pyi
+++ b/line_profiler/scoping_policy.pyi
@@ -5,6 +5,7 @@ from .line_profiler_utils import StringEnum
 
 
 class ScopingPolicy(StringEnum):
+    EXACT = auto()
     CHILDREN = auto()
     DESCENDANTS = auto()
     SIBLINGS = auto()

--- a/line_profiler/toml_config.pyi
+++ b/line_profiler/toml_config.pyi
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-from pathlib import Path, PurePath
-from typing import (List, Dict, Set, Tuple,
-                    Mapping, Sequence,
-                    Any, Self, TypeVar, Union)
+from os import PathLike
+from pathlib import Path
+from typing import Mapping, Sequence, Any, Self, TypeVar
 
 
 TARGETS = 'line_profiler.toml', 'pyproject.toml'
@@ -10,15 +9,15 @@ ENV_VAR = 'LINE_PROFILER_RC'
 
 K = TypeVar('K')
 V = TypeVar('V')
-Config = Tuple[Dict[str, Dict[str, Any]], Path]
-NestedTable = Mapping[K, Union['NestedTable[K, V]', V]]
+Config = tuple[dict[str, dict[str, Any]], Path]
+NestedTable = Mapping[K, 'NestedTable[K, V]' | V]
 
 
 @dataclass
 class ConfigSource:
-    conf_dict: Dict[str, Any]
-    source: Path
-    subtable: List[str]
+    conf_dict: dict[str, Any]
+    path: Path
+    subtable: list[str]
 
     def copy(self) -> Self:
         ...
@@ -32,16 +31,16 @@ class ConfigSource:
         ...
 
     @classmethod
-    def from_config(cls, config: Union[str, PurePath, bool, None] = None, *,
+    def from_config(cls, config: str | PathLike | bool | None = None, *,
                     read_env: bool = True) -> Self:
         ...
 
 
 def find_and_read_config_file(
         *,
-        config: Union[str, PurePath, None] = None,
-        env_var: Union[str, None] = ENV_VAR,
-        targets: Sequence[Union[str, PurePath]] = TARGETS) -> Config:
+        config: str | PathLike | None = None,
+        env_var: str | None = ENV_VAR,
+        targets: Sequence[str | PathLike] = TARGETS) -> Config:
     ...
 
 
@@ -51,5 +50,5 @@ def get_subtable(table: NestedTable[K, V], keys: Sequence[K], *,
 
 
 def get_headers(table: NestedTable[K, Any], *,
-                include_implied: bool = False) -> Set[Tuple[K, ...]]:
+                include_implied: bool = False) -> set[tuple[K, ...]]:
     ...


### PR DESCRIPTION
This PR addresses the following issues with recent PRs. (Note that there is no actual behavior change on the code-side).

# Typing bugs

- `line_profiler.cli_utils.add_argument(ArgumentParser(...), ...)` actually fails type check. 
- The stubs for the following types are botched:
  - `line_profiler.toml_config.ConfigSource` should have a `.path` field instead of a `.source` field.
  - `line_profiler.scoping_policy.ScopingPolicy` is missing an `.EXACT` item.

These typing bugs went under our nose because we only do stubs, and thus `mypy` don't really look into how we're using any of these. But `mypy` flared up the moment I installed the `line_profiler` in  a non-editable way in another project, which got me investigating... and here we are. This PR remedies the above bugs.

While we're at it, I also updated the stubs for `line_profiler.profiler_mixin.ByCountProfilerMixin.wrap_*()` and `line_profiler.line_profiler.LineProfiler.__call__()` so that we get better parametrizations for the param specs and return values (e.g. `p: partial[int] = ...; p_profiled = reveal_type(profile(p))` gives `partial[int]` instead of `partial[Any]`).

# Lacking docs

Shortly after finishing #335 I realized that we never explained whence the config file is looked up (i.e. the current directory's and its ancestors' `line_profiler.toml` and `pyproject.toml`) in the online docs, because neither `line_profiler.toml_config.find_and_read_config_file()` nor `.TARGETS` is in `.__all__`, and they are thus omitted from the built doc pages. The PR thus rewrites the docstring for `line_profiler.toml_config.ConfigSource.from_config()` to (1) be more clear, and (2) document the aforementioned lookup targets and mechanism.