### PR TITLE
FIX: ref-count leaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changes
 
 5.0.1
 ~~~~~
+* FIX: ref-count leaks #372
 
 5.0.0
 ~~~~~


### PR DESCRIPTION
Closes #371 (maybe? see Caveats).

Code changes
---
- `line_profiler/_line_profiler.pyx`:  
  Added `Py_XDECREF()` calls to temp objects used in the bodies of `_SysMonitoringState.call_callback()` and `legacy_trace_callback()`

Test changes
---
- `tests/test_line_profiler.py`:  
  Updated the following tests to test that no ref counts leak for code objects:
  - `test_double_decoration()`
  - `test_function_decorator()`
  - `test_gen_decorator()`
  - `test_coroutine_decorator()`
  - `test_async_gen_decorator()`
- `tests/test_sys_monitoring.py`:  
  Updated `test_wrapping_trace()` to test that no ref counts leak for the return value of `sys.monitoring` tracebacks

Caveats
---
One of the subtests in `tests/test_line_profiler.py::test_async_gen_decorator()` is XFAIL-ed in Python 3.12+;
unlike the other 4 analogous tests, it seems that unless one explicitly called `gc.collect()` before doing `sys.getrefcount()`, the GC fails in cleaning up all stray references to the `.__code__` of the async gen function. The cause is yet unclear – especially since it seems to happen no matter if using `LINE_PROFILER_CORE=ctrace` or `sysmon`.