### PR TITLE
Speed Up Worst-Case Overhead

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changes
 ~~~~~
 * FIX: ref-count leaks #372
 * ENH: Add support for building ABI3 wheels
+* FIX: mitigate speed regressions introduced in 5.0.0
 
 5.0.0
 ~~~~~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ recursive-include requirements *.txt
 recursive-include tests *.py
 recursive-include line_profiler *.txt
 recursive-include line_profiler *.pyx
+recursive-include line_profiler *.pyi
 recursive-include line_profiler *.pxd
 recursive-include line_profiler *.pyd
 recursive-include line_profiler *.c

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -19,6 +19,8 @@ if ! which cibuildwheel ; then
 fi
 
 
-#pip wheel -w wheelhouse .
-# python -m build --wheel -o wheelhouse  #  line_profiler: +COMMENT_IF(binpy)
-cibuildwheel --config-file pyproject.toml --platform linux --archs x86_64  #  line_profiler: +UNCOMMENT_IF(binpy)
+# Build ABI3 wheels
+CIBW_CONFIG_SETTINGS="--build-option=--py-limited-api=cp38" CIBW_BUILD="cp38-*" cibuildwheel --config-file pyproject.toml --platform linux --archs x86_64
+
+# Build version-pinned wheels
+cibuildwheel --config-file pyproject.toml --platform linux --archs x86_64

--- a/clean.sh
+++ b/clean.sh
@@ -5,6 +5,8 @@ rm -rf _skbuild
 rm -rf _line_profiler.c
 rm -rf *.so
 rm -rf line_profiler/_line_profiler.c
+rm -rf line_profiler/_line_profiler.cpp
+rm -rf line_profiler/*.html
 rm -rf line_profiler/*.so
 rm -rf build
 rm -rf line_profiler.egg-info

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -112,9 +112,8 @@ cdef extern from "Python_wrapper.h":
 
     cdef int PyFrame_GetLineNumber(PyFrameObject *frame)
     cdef void Py_XDECREF(PyObject *o)
-    
-    # it's actually an unsigned long, but we want to avoid truncation on windows
-    cdef unsigned long long PyThread_get_thread_ident()
+
+    cdef unsigned long PyThread_get_thread_ident()
     cdef Py_hash_t hash_bytecode(PyObject *bytestring, const char* bytes,
                                  Py_ssize_t len)
 
@@ -1442,6 +1441,7 @@ cdef inline inner_trace_callback(
     for i in range(size):
         if data[i]:
             # block_hash = hash_bytecode(<PyObject *>py_bytes_obj, data, size)
+            # because we use Python functions like hash, we CANNOT mark this function as nogil
             block_hash = hash(py_bytes_obj)
             break
     else:  # fallback for Cython functions

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -577,7 +577,7 @@ sys.monitoring.html#monitoring-event-RERAISE
     """
     cdef TraceCallback *legacy_callback
     cdef _SysMonitoringState mon_state
-    cdef public object active_instances  # type: set[LineProfiler]
+    cdef public set active_instances  # type: set[LineProfiler]
     cdef int _wrap_trace
     cdef int _set_frame_local_trace
     cdef int recursion_guard
@@ -1415,11 +1415,11 @@ datamodel.html#user-defined-functions
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef inline inner_trace_callback(
-        int is_line_event, object instances, object code, int lineno):
+        int is_line_event, set instances, object code, int lineno):
     """
     The basic building block for the trace callbacks.
     """
-    cdef object prof_
+    cdef LineProfiler prof_
     cdef LineProfiler prof
     cdef LastTime old
     cdef int key

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -1457,7 +1457,7 @@ cdef inline inner_trace_callback(
         if not has_time:
             time = hpTimer()
             has_time = True
-        ident = PyThread_get_thread_ident()
+        ident = threading.get_ident() # PyThread_get_thread_ident()
         last_map = &(prof._c_last_time[ident])
         if deref(last_map).count(block_hash):
             old = deref(last_map)[block_hash]

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -1440,7 +1440,10 @@ cdef inline inner_trace_callback(
     # in tests it only seems to add overhead...
     for i in range(size):
         if data[i]:
+            # hash_bytecode is currently unused due to test issues on Windows with PyObject_Hash
+            # but we plan to fix those and enable it shortly
             # block_hash = hash_bytecode(<PyObject *>py_bytes_obj, data, size)
+
             # because we use Python functions like hash, we CANNOT mark this function as nogil
             block_hash = hash(py_bytes_obj)
             break
@@ -1460,6 +1463,9 @@ cdef inline inner_trace_callback(
             has_time = True
         ident = PyThread_get_thread_ident()
         last_map = &(prof._c_last_time[ident])
+        # deref() is Cython's version of the -> accessor in C++. if we don't use deref then
+        # Cython thinks that when we index last_map,
+        # we want pointer indexing (which is not the case)
         if deref(last_map).count(block_hash):
             old = deref(last_map)[block_hash]
             line_entries = &(prof._c_code_map[code_hash])

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -1457,7 +1457,7 @@ cdef inline inner_trace_callback(
         if not has_time:
             time = hpTimer()
             has_time = True
-        ident = threading.get_ident() # PyThread_get_thread_ident()
+        ident = PyThread_get_thread_ident()
         last_map = &(prof._c_last_time[ident])
         if deref(last_map).count(block_hash):
             old = deref(last_map)[block_hash]

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -19,7 +19,7 @@ from sys import byteorder
 import sys
 cimport cython
 from cython.operator cimport dereference as deref
-from cpython.object cimport PyObject_Hash, Py_hash_t
+from cpython.object cimport PyObject_Hash
 from cpython.bytes cimport PyBytes_AS_STRING, PyBytes_GET_SIZE
 from cpython.version cimport PY_VERSION_HEX
 from libc.stdint cimport int64_t
@@ -88,6 +88,7 @@ cdef extern from "Python_wrapper.h":
     ctypedef struct PyObject
     ctypedef struct PyCodeObject
     ctypedef struct PyFrameObject
+    ctypedef Py_ssize_t Py_hash_t
     ctypedef long long PY_LONG_LONG
     ctypedef int (*Py_tracefunc)(
         object self, PyFrameObject *py_frame, int what, PyObject *arg)
@@ -112,7 +113,8 @@ cdef extern from "Python_wrapper.h":
     cdef int PyFrame_GetLineNumber(PyFrameObject *frame)
     cdef void Py_XDECREF(PyObject *o)
     
-    cdef unsigned long PyThread_get_thread_ident()
+    # it's actually an unsigned long, but we want to avoid truncation on windows
+    cdef unsigned long long PyThread_get_thread_ident()
     cdef Py_hash_t hash_bytecode(PyObject *bytestring, const char* bytes,
                                  Py_ssize_t len)
 

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -114,7 +114,7 @@ cdef extern from "Python_wrapper.h":
     cdef void Py_XDECREF(PyObject *o)
     
     # it's actually an unsigned long, but we want to avoid truncation on windows
-    cdef unsigned long long PyThread_get_thread_ident()
+    cdef uint64_t PyThread_get_thread_ident()
     cdef Py_hash_t hash_bytecode(PyObject *bytestring, const char* bytes,
                                  Py_ssize_t len)
 
@@ -577,7 +577,7 @@ sys.monitoring.html#monitoring-event-RERAISE
     """
     cdef TraceCallback *legacy_callback
     cdef _SysMonitoringState mon_state
-    cdef public set active_instances  # type: set[LineProfiler]
+    cdef public object active_instances  # type: set[LineProfiler]
     cdef int _wrap_trace
     cdef int _set_frame_local_trace
     cdef int recursion_guard
@@ -1415,11 +1415,11 @@ datamodel.html#user-defined-functions
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef inline inner_trace_callback(
-        int is_line_event, set instances, object code, int lineno):
+        int is_line_event, object instances, object code, int lineno):
     """
     The basic building block for the trace callbacks.
     """
-    cdef LineProfiler prof_
+    cdef object prof_
     cdef LineProfiler prof
     cdef LastTime old
     cdef int key

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -87,7 +87,6 @@ cdef extern from "Python_wrapper.h":
     """
     ctypedef struct PyObject
     ctypedef struct PyCodeObject
-    ctypedef long Py_hash_t
     ctypedef struct PyFrameObject
     ctypedef long long PY_LONG_LONG
     ctypedef int (*Py_tracefunc)(
@@ -1428,7 +1427,6 @@ cdef inline inner_trace_callback(
     cdef object py_bytes_obj = code.co_code
     cdef char* data = PyBytes_AS_STRING(py_bytes_obj)
     cdef Py_ssize_t size = PyBytes_GET_SIZE(py_bytes_obj)
-    cdef unsigned long ident
     cdef Py_hash_t block_hash
     cdef LineTime *entry
     cdef unordered_map[int64, LineTime] *line_entries

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -114,7 +114,7 @@ cdef extern from "Python_wrapper.h":
     cdef void Py_XDECREF(PyObject *o)
     
     # it's actually an unsigned long, but we want to avoid truncation on windows
-    cdef uint64_t PyThread_get_thread_ident()
+    cdef unsigned long long PyThread_get_thread_ident()
     cdef Py_hash_t hash_bytecode(PyObject *bytestring, const char* bytes,
                                  Py_ssize_t len)
 
@@ -1442,10 +1442,10 @@ cdef inline inner_trace_callback(
     for i in range(size):
         if data[i]:
             # block_hash = hash_bytecode(<PyObject *>py_bytes_obj, data, size)
-            block_hash = PyObject_Hash(py_bytes_obj)
+            block_hash = hash(py_bytes_obj)
             break
     else:  # fallback for Cython functions
-        block_hash = PyObject_Hash(code)
+        block_hash = hash(code)
 
     code_hash = compute_line_hash(block_hash, lineno)
 

--- a/line_profiler/_map_helpers.pxd
+++ b/line_profiler/_map_helpers.pxd
@@ -1,0 +1,35 @@
+# cython: language_level=3
+# cython: legacy_implicit_noexcept=True
+# used in _line_profiler.pyx
+from libcpp.unordered_map cimport unordered_map
+from cython.operator cimport dereference as deref
+
+# long long int is at least 64 bytes assuming c99
+ctypedef long long int int64
+
+cdef extern from "Python_wrapper.h":
+    ctypedef long long PY_LONG_LONG
+
+cdef struct LastTime:
+    int f_lineno
+    PY_LONG_LONG time
+
+cdef struct LineTime:
+    long long code
+    int lineno
+    PY_LONG_LONG total_time
+    long nhits
+
+# Types used for mappings from code hash to last/line times.
+ctypedef unordered_map[int64, LastTime] LastTimeMap
+ctypedef unordered_map[int64, LineTime] LineTimeMap
+
+cdef inline void last_erase_if_present(LastTimeMap* m, int64 key) noexcept:
+    cdef LastTimeMap.iterator it = deref(m).find(key)
+    if it != deref(m).end():
+        deref(m).erase(it)
+
+cdef inline LineTime* line_ensure_entry(LineTimeMap* m, int lineno, long long code_hash) noexcept:
+    if not deref(m).count(lineno):
+        deref(m)[lineno] = LineTime(code_hash, lineno, 0, 0)
+    return &(deref(m)[lineno])

--- a/setup.py
+++ b/setup.py
@@ -231,6 +231,10 @@ if __name__ == '__main__':
                     sources=["line_profiler/_line_profiler.pyx",
                              "line_profiler/timers.c",
                              "line_profiler/c_trace_callbacks.c"],
+                    # force a recompile if this changes
+                    depends=[
+                        "line_profiler/_map_helpers.pxd",
+                    ],
                     language="c++",
                     define_macros=[("CYTHON_TRACE", (1 if os.getenv("DEV") == "true" else 0))],
                 ),
@@ -240,7 +244,7 @@ if __name__ == '__main__':
                     "legacy_implicit_noexcept": True,
                     "linetrace": (True if os.getenv("DEV") == "true" else False)
                 },
-                include_path=["line_profiler/python25.pxd"],
+                include_path=["line_profiler/python25.pxd", "line_profiler/_map_helpers.pxd"],
                 force=force,
                 nthreads=multiprocessing.cpu_count(),
             )
@@ -294,7 +298,6 @@ if __name__ == '__main__':
     setupkw["classifiers"] = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: C',
         'Programming Language :: Python',


### PR DESCRIPTION
The following PR transforms this callback to this. More yellow is worse.
Before:
<img width="680" height="789" alt="image" src="https://github.com/user-attachments/assets/718301dd-b8f9-4a8e-b592-c26bd84471b6" />
After:
<img width="788" height="962" alt="image" src="https://github.com/user-attachments/assets/34489e4d-2d13-4dbb-8887-3f5dd1cde835" />

The final result is to lower the worst-case overhead from ~60x to ~40x, which gets closer to the ~25-30x measured in 4.1.3. The average overhead remains at ~2x. Worst-case overhead output below:
```
kernprof -lvz test.py
Time Elapsed without profiling: 90.72ms
Time Elapsed profiling: 3686.82ms
Slowdown from profiling: 3596.1000000000004ms, 40.64x
Wrote profile results to 'test.py.lprof'
Timer unit: 1e-06 s

Total time: 2.78653 s
File: test.py
Function: main at line 3

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     3                                           def main(profiled=False):
     4         1          2.9      2.9      0.0      start = time.perf_counter()
     5   2000001    1401860.4      0.7     50.3      for x in range(2000000): #2000000
     6   2000000    1384564.3      0.7     49.7          y = x
     7         1         31.1     31.1      0.0      elapsed_ms = round((time.perf_counter()-start)*1000, 2)
     8         1          1.2      1.2      0.0      if profiled:
     9         1         60.8     60.8      0.0          print(f"Time Elapsed profiling: {elapsed_ms}ms")
    10                                               else:
    11                                                   print(f"Time Elapsed without profiling: {elapsed_ms}ms")
    12         1          4.9      4.9      0.0      return elapsed_ms
```