### PR TITLE
ENH: `LineStats` aggregation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@ Changes
   * ``kernprof`` and ``python -m line_profiler`` CLI options
   * ``GlobalProfiler`` configurations, and
   * profiler output (e.g. ``LineProfiler.print_stats()``) formatting
+* ENH: Added capability to combine profiling data both programmatically (``LineStats.__add__()``) and via the CLI (``python -m line_profiler``) (#380, originally proposed in #219)
 
 4.2.0
 ~~~~~

--- a/line_profiler/__init__.py
+++ b/line_profiler/__init__.py
@@ -251,7 +251,7 @@ mkinit ./line_profiler/__init__.py --relative -w
 # NOTE: This needs to be in sync with ../kernprof.py and line_profiler.py
 __version__ = '5.0.1'
 
-from .line_profiler import (LineProfiler,
+from .line_profiler import (LineProfiler, LineStats,
                             load_ipython_extension, load_stats, main,
                             show_func, show_text,)
 
@@ -259,6 +259,6 @@ from .line_profiler import (LineProfiler,
 from .explicit_profiler import profile
 
 
-__all__ = ['LineProfiler', 'line_profiler',
+__all__ = ['LineProfiler', 'LineStats', 'line_profiler',
            'load_ipython_extension', 'load_stats', 'main', 'show_func',
            'show_text', '__version__', 'profile']

--- a/line_profiler/line_profiler.pyi
+++ b/line_profiler/line_profiler.pyi
@@ -1,16 +1,20 @@
 import io
-import pathlib
 from functools import cached_property, partial, partialmethod
 from os import PathLike
 from types import FunctionType, ModuleType
-from typing import TYPE_CHECKING, overload, Callable, Literal, Mapping, TypeVar
+from typing import (TYPE_CHECKING,
+                    overload,
+                    Callable, Mapping,
+                    Literal, Self,
+                    Protocol, TypeVar)
 try:
     from typing import (  # type: ignore[attr-defined]  # noqa: F401
         ParamSpec)
 except ImportError:
     from typing_extensions import ParamSpec  # noqa: F401
 from _typeshed import Incomplete
-from ._line_profiler import LineProfiler as CLineProfiler
+from ._line_profiler import (LineProfiler as CLineProfiler,
+                             LineStats as CLineStats)
 from .profiler_mixin import ByCountProfilerMixin, CLevelCallable
 from .scoping_policy import ScopingPolicy, ScopingPolicyDict
 
@@ -31,6 +35,42 @@ def get_column_widths(
 
 def load_ipython_extension(ip) -> None:
     ...
+
+
+class _StatsLike(Protocol):
+    timings: Mapping[tuple[str, int, str],  # funcname, lineno, filename
+                     list[tuple[int, int, int]]]  # lineno, nhits, time
+    unit: float
+
+
+class LineStats(CLineStats):
+    def to_file(self, filename: PathLike[str] | str) -> None:
+        ...
+
+    def print(self, stream: Incomplete | None = None, **kwargs) -> None:
+        ...
+
+    @classmethod
+    def from_files(cls, file: PathLike[str] | str, /,
+                   *files: PathLike[str] | str) -> Self:
+        ...
+
+    @classmethod
+    def from_stats_objects(cls, stats: _StatsLike, /,
+                           *more_stats: _StatsLike) -> Self:
+        ...
+
+    def __repr__(self) -> str:
+        ...
+
+    def __eq__(self, other: _StatsLike) -> bool:
+        ...
+
+    def __add__(self, other: _StatsLike) -> Self:
+        ...
+
+    def __iadd__(self, other: _StatsLike) -> Self:
+        ...
 
 
 class LineProfiler(CLineProfiler, ByCountProfilerMixin):
@@ -84,6 +124,9 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
             self, func,
             guard: Callable[[FunctionType], bool] | None = None,
             name: str | None = None) -> Literal[0, 1]:
+        ...
+
+    def get_stats(self) -> LineStats:
         ...
 
     def dump_stats(self, filename) -> None:
@@ -148,8 +191,7 @@ def show_text(stats,
     ...
 
 
-def load_stats(filename):
-    ...
+load_stats = LineStats.from_files
 
 
 def main():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,13 @@ from contextlib import nullcontext
 from functools import partial
 from io import StringIO
 from os.path import join
+from runpy import run_module
 from shlex import split
-from sys import executable
+from sys import argv, executable, stderr
 from tempfile import TemporaryDirectory
 import pytest
 import ubelt as ub
+from line_profiler import LineProfiler
 from line_profiler.cli_utils import add_argument
 
 
@@ -160,79 +162,66 @@ def test_cli():
         assert '7       100' in info['out']
 
 
-def test_multiple_lprof_files():
+def test_multiple_lprof_files(capsys):
     """
-    Test that we can aggregate profiling results.
+    Test that we can aggregate profiling results with
+    ``python -m line_profiler``.
     """
-    code = ub.codeblock("""
-    from argparse import ArgumentParser
-    from typing import Sequence, Optional
-
     def sum_n(n: int) -> int:
         x = 0
         for n in range(1, n + 1):
             x += n  # Loop: sum_n
-        return x
-
+        return x  # Return: sum_n
 
     def sum_nsq(n: int) -> int:
         x = 0
         for n in range(1, n + 1):
             x += n * n  # Loop: sum_nsq
-        return x
+        return x  # Return: sum_nsq
 
+    profs = {0: LineProfiler(sum_n),
+             1: LineProfiler(sum_nsq),
+             2: LineProfiler(sum_n, sum_nsq)}
 
-    def positive_int(x: str) -> int:
-        result = int(x)
-        if result > 0:
-            return result
-        raise ValueError
-
-
-    def main(args: Optional[Sequence[str]] = None) -> None:
-        parser = ArgumentParser()
-        parser.add_argument('--pow',
-                            choices=[1, 2], default=1, type=int)
-        parser.add_argument('n', type=positive_int)
-        options = parser.parse_args()
-        func, pattern = {1: (sum_n, '1 + ... + {} = {}'),
-                         2: (sum_nsq, '1 + ... + {}^2 = {}')}[options.pow]
-        print(pattern.format(options.n, func(options.n)))
-
-
-    if __name__ == '__main__':
-        main()
-    """)
     with TemporaryDirectory() as tmp_dpath:
-        tmp_src_fpath = join(tmp_dpath, 'foo.py')
-        with open(tmp_src_fpath, 'w') as file:
-            file.write(code)
-
-        # Run kernprof on it
+        # Write several profiling output files
         stats_files = []
-        nloops = {}
-        for i, (pow, n, expected) in enumerate([
-                (1, 10, '1 + ... + 10 = 55'),
-                (2, 20, '1 + ... + 20^2 = 2870'),
-                (1, 30, '1 + ... + 30 = 465')]):
-            stats = f'{i}.lprof'
-            kcmd = ['kernprof',
-                    '-l', '-o', stats, '-p', tmp_src_fpath, tmp_src_fpath, '--',
-                    '--pow', str(pow), str(n)]
+        nhits = {}
+        for i, (func, n, expected) in enumerate([
+                (sum_n, 10, 10 * 11 // 2),
+                (sum_nsq, 20, 20 * 21 * 41 // 6),
+                (sum_n, 30, 30 * 31 // 2)]):
+            prof = profs[i]
+            with prof:
+                assert func(n) == expected
+            stats = join(tmp_dpath, f'{i}.lprof')
             stats_files.append(stats)
-            nloops[pow] = nloops.get(pow, 0) + n
-            kinfo = ub.cmd(kcmd, verbose=3, cwd=tmp_dpath)
-            kinfo.check_returncode()
-            assert expected in kinfo.stdout
+            prev_loop, prev_return = nhits.get(func, (0, 0))
+            nhits[func] = prev_loop + n, prev_return + 1
+            prof.dump_stats(stats)
 
-        # Check the output
-        lcmd = [executable, '-m', 'line_profiler', *stats_files]
-        linfo = ub.cmd(lcmd, cwd=tmp_dpath, verbose=3)
-        linfo.check_returncode()
-        for func, nhits in ('sum_n', nloops[1]), ('sum_nsq', nloops[2]):
-            line, = (line for line in linfo.stdout.splitlines()
-                     if line.endswith('# Loop: ' + func))
-            assert int(line.split()[1]) == nhits
+        old_argv = argv.copy()
+        argv[:] = ['line_profiler', *stats_files]
+        try:
+            run_module('line_profiler', run_name='__main__', alter_sys=True)
+        finally:
+            argv[:] = old_argv
+
+    # View them and check the output
+    checks = {}
+    out, err = capsys.readouterr()
+    with capsys.disabled():
+        print(out, end='')
+        print(err, end='', file=stderr)
+    for func in sum_n, sum_nsq:
+        for comment, n in zip(['Loop', 'Return'], nhits[func]):
+            checks[f'  # {comment}: {func.__name__}'] = n
+    for line in out.splitlines():
+        try:
+            suffix, = (suffix for suffix in checks if line.endswith(suffix))
+        except ValueError:  # No match
+            continue
+        assert int(line.split()[1]) == checks.pop(suffix)
 
 
 def test_version_agreement():


### PR DESCRIPTION
(Based on @Marxlp's #219 and the changes I proposed there.)

Code changes
---
- `line_profiler/line_profiler.py[i]`
  - `LineStats`:
    New API subclass of `line_profiler/_line_profiler.pyx::LineStats` which provides the following convenience methods:
    - `__add__()`, `__iadd__()`, `from_stats_objects()`:  
      Methods for aggregating the timing data between instances
    - `to_file()`, `from_files()`, `print()`:  
      IO methods
    - `__eq__()`:  
      Method for comparing instances
  - `LineProfiler.get_stats()`, `.dump_stats()`, `.print_stats()`:  
    Refactored to return/use the new `LineStats` class
  - `main()`:
    Updated to allow for passing more than one `.lprof` files

Tests changes
---
- `tests/test_cli.py::test_multiple_lprof_files()`:  
  New test checking that `python -m line_profiler` handles multiple `.lprof` files correctly
- `tests/test_line_profiler.py::test_load_stats_files()`:  
  New test checking that `LineStats.from_files()` reads one or more `.lprof` files correctly, and handles `.lprof` (pickle) files generated by both new and old versions of `line_profiler`