### PR TITLE
FIX: doc-searching

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,9 @@
 # Required
 version: 2
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "3.13"
 sphinx:
   configuration: docs/source/conf.py
 formats: all

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changes
 * FIX: ref-count leaks #372
 * ENH: Add support for building ABI3 wheels
 * FIX: mitigate speed regressions introduced in 5.0.0
+* ENH: Added capability to combine profiling data both programmatically (``LineStats.__add__()``) and via the CLI (``python -m line_profiler``) (#380, originally proposed in #219)
+* FIX: search function in online documentation
 
 5.0.0
 ~~~~~
@@ -54,7 +56,6 @@ Changes
   * ``kernprof`` and ``python -m line_profiler`` CLI options
   * ``GlobalProfiler`` configurations, and
   * profiler output (e.g. ``LineProfiler.print_stats()``) formatting
-* ENH: Added capability to combine profiling data both programmatically (``LineStats.__add__()``) and via the CLI (``python -m line_profiler``) (#380, originally proposed in #219)
 
 4.2.0
 ~~~~~

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,6 +173,7 @@ extensions = [
     'sphinx.ext.imgconverter',  # For building latexpdf
     'sphinx.ext.githubpages',
     # 'sphinxcontrib.redirects',
+    'sphinxcontrib.jquery',  # Fix for search
     'sphinx_reredirects',
 ]
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 sphinx >= 5.0.1
 sphinx-autobuild >= 2021.3.14
-sphinx_rtd_theme >= 1.0.0
+sphinx_rtd_theme >= 1.2.1
 sphinxcontrib-napoleon >= 0.7
 sphinx-autoapi >= 1.8.4
 Pygments >= 2.9.0


### PR DESCRIPTION
Closes #292.

This PR implements the proposed fixes in the issue, attempting to fix the search function in the docs based on readthedocs/sphinx_rtd_theme#1448 and the associated thread:

- `docs/source/cont.py`:  
  `sphinxcontrib.jquery` is added as a Sphinx extension so there is a search to fall back on; this also allows for searches to work on local doc builds.
- `requirements/docs.txt`:  
  Bumped `sphinx_rtd_theme` to a version (1.2.1) containing the linked PR fixing the issue.
- `.readthedocs.yml`:  
  Bumped the build environment (Docker image and Python version) to something reasonably new but not bleeding-edge. 