### PR TITLE
FIX: Installing IPython when building RTD docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,5 @@ formats: all
 python:
   install:
   - requirements: requirements/docs.txt
-  # Make sure we build the docs for `line_profiler.ipython_extension`
-  - requirements: requirements/ipython.txt
   - method: pip
     path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,5 +17,7 @@ formats: all
 python:
   install:
   - requirements: requirements/docs.txt
+  # Make sure we build the docs for `line_profiler.ipython_extension`
+  - requirements: requirements/ipython.txt
   - method: pip
     path: .

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,3 +6,5 @@ sphinx-autoapi >= 1.8.4
 Pygments >= 2.9.0
 myst_parser >= 0.18.0
 sphinx-reredirects >= 0.0.1
+# Make sure we build the docs for `line_profiler.ipython_extension`
+-r ipython.txt


### PR DESCRIPTION
Right now [the online docs for `line_profiler.ipython_extension` are empty](https://kernprof.readthedocs.io/en/latest/auto/line_profiler.ipython_extension.html), probably because IPython is not installed in the build environment and thus said module is unavailable at build time. Considering the recent efforts on improving said module (#383) and inquiries thereon (#382), it makes sense for its docs to at least be publicly accessible.

Hence, this PR updates ~~`.readthedocs.yml`~~ **`requirements/docs.txt`** so that ReadTheDocs build the doc pages with IPython installed, and `autodocs` can thus (presumably and hopefully) build the page for the aforementioned submodule.