### PR TITLE
FIX: use import system to resolve file executed by `kernprof -m`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changes
 * FIX: mitigate speed regressions introduced in 5.0.0
 * ENH: Added capability to combine profiling data both programmatically (``LineStats.__add__()``) and via the CLI (``python -m line_profiler``) (#380, originally proposed in #219)
 * FIX: search function in online documentation
+* FIX: Use import system to locate module file run by ``kernprof -m`` #389
 
 5.0.0
 ~~~~~

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -125,35 +125,40 @@ def test_kernprof_m_sys_modules(flags, profiled_main):
     assert ('Function: main' in proc.stdout) == profiled_main
 
 
+@pytest.mark.parametrize('autoprof', [True, False])
 @pytest.mark.parametrize('static', [True, False])
-def test_kernprof_m_import_resolution(static):
+def test_kernprof_m_import_resolution(static, autoprof):
     """
     Test that `kernprof -m` resolves the module using static and dynamic
     as is appropriate (toggled by the undocumented environment variable
     :env:`LINE_PROFILER_STATIC_ANALYSIS`; note that static analysis
     doesn't handle namespace modules while dynamic resolution does.
     """
+    code = ub.codeblock('''
+    import enum
+    import os
+    import sys
+
+
+    @profile
+    def main():
+        print('Hello world')
+
+
+    if __name__ == '__main__':
+        main()
+    ''')
+    cmd = [sys.executable, '-m', 'kernprof', '-lv']
+    if autoprof:
+        # Remove the explicit decorator, and use the `--prof-mod` flag
+        code = '\n'.join(line for line in code.splitlines()
+                         if '@profile' not in line)
+        cmd += ['-p', 'my_namesapce_pkg.mysubmod']
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_dpath = ub.Path(tmpdir)
         namespace_mod_path = temp_dpath / 'my_namesapce_pkg' / 'mysubmod.py'
         namespace_mod_path.parent.mkdir()
-        namespace_mod_path.write_text(ub.codeblock(
-            '''
-            import enum
-            import os
-            import sys
-
-
-            @profile
-            def main():
-                print('Hello world')
-
-
-            if __name__ == '__main__':
-                main()
-            '''))
-        cmd = [sys.executable, '-m', 'kernprof',
-               '-lv', '-m', 'my_namesapce_pkg.mysubmod']
+        namespace_mod_path.write_text(code)
         python_path = tmpdir
         if 'PYTHONPATH' in os.environ:
             python_path += ':' + os.environ['PYTHONPATH']
@@ -162,6 +167,7 @@ def test_kernprof_m_import_resolution(static):
                'LINE_PROFILER_STATIC_ANALYSIS': str(bool(static)),
                # Add the tempdir to `sys.path`
                'PYTHONPATH': python_path}
+        cmd += ['-m', 'my_namesapce_pkg.mysubmod']
         proc = ub.cmd(cmd, cwd=temp_dpath, verbose=2, env=env)
     if static:
         assert proc.returncode


### PR DESCRIPTION
Closes #387.

Motivation
---

In #323 we used `line_profiler.autoprofile.util_static.modname_to_modpath()` to statically resolve the `some.module` in `kernprof -m some.module` to the file path from which the module's source file can be found. This is all well and good, but doesn't take into account some intricacies of the import system, e.g. namespace packages (see the rather lengthy discussion at #387).

Since the profiled module is not directly executed – instead, its source file is retrieved, suitably processed into a code object, which is then executed – the side effects of going through the import system (e.g. importing parent packages) are acceptable and does not affect profiling. Moreover, since `kernprof -m` aims to adhere to the behavior of `python -m` as far as possible, it makes sense to use the import system directly to locate said source file. Finally, as noted in the aforementioned discussion, the import system is also more performant than resolution through static analysis.

Changes
---
- `kernprof.py`:
  - `find_module_script()`:  
    Added new `static` argument, which allows for toggling between `importlib`- and static-analysis-based resolution of the module source file
  - `_pre_profile()`:  
    Now calling `find_module_script()` with `static` set according to the undocumented "dev-mode" toggle `${LINE_PROFILER_STATIC_ANALYSIS}`; default is now false, meaning to use the `importlib`-based solution
- `tests/test_kernprof.py::test_kernprof_m_import_resolution()`:  
  New test for the toggling between dynamic and static resolution of the module run by `kernprof -m`: the former catches namespace packages, while the latter doesn't