### PR TITLE
Win arm64 fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -236,6 +236,7 @@ jobs:
           install-extras: tests-strict,runtime-strict
           os: windows-latest
           arch: auto
+        # Note: cibuildwheel can't target 3.8 on Window ARM64
         - python-version: '3.13'
           install-extras: tests-strict,runtime-strict,optional-strict
           os: ubuntu-latest
@@ -247,6 +248,10 @@ jobs:
         - python-version: '3.13'
           install-extras: tests-strict,runtime-strict,optional-strict
           os: windows-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests-strict,runtime-strict,optional-strict
+          os: windows-11-arm
           arch: auto
         - python-version: '3.13'
           install-extras: tests
@@ -256,6 +261,10 @@ jobs:
           install-extras: tests
           os: windows-latest
           arch: auto
+        - python-version: '3.13'
+          install-extras: tests
+          os: windows-11-arm
+          arch: auto
         - python-version: '3.8'
           install-extras: tests,optional
           os: ubuntu-latest
@@ -339,13 +348,38 @@ jobs:
         - python-version: 3.14.0-rc.1
           install-extras: tests,optional
           os: windows-latest
+          arch: auto
+        # Note: again, cibuildwheel can't target 3.8 on Window ARM64
+        - python-version: '3.9'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.10'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.12'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: 3.14.0-rc.1
+          install-extras: tests,optional
+          os: windows-11-arm
           arch: auto
     steps:
     - name: Checkout source
       uses: actions/checkout@v4.2.2
     - name: Enable MSVC 64bit
       uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows-')
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       if: runner.os == 'Linux' && matrix.arch != 'auto'

--- a/line_profiler/c_trace_callbacks.h
+++ b/line_profiler/c_trace_callbacks.h
@@ -24,17 +24,17 @@
 #   ifndef Py_BUILD_CORE
 #       define Py_BUILD_CORE 1
 #   endif
-#   ifdef _PyGC_FINALIZED
-#       undef _PyGC_FINALIZED
+#   if PY_VERSION_HEX < 0x030d0000  // 3.13
+#       ifdef _PyGC_FINALIZED
+#           undef _PyGC_FINALIZED
+#       endif
+#       ifdef __linux__
+#           ifdef HAVE_STD_ATOMIC
+#               undef HAVE_STD_ATOMIC
+#           endif
+#       endif
 #   endif
-#   ifdef HAVE_STD_ATOMIC
-#       undef HAVE_STD_ATOMIC
-#   endif
-#   if PY_VERSION_HEX >= 0x030900a6  // 3.9.0a6
-#      include "internal/pycore_interp.h"
-#   else
-#      include "internal/pycore_pystate.h"
-#   endif
+#   include "internal/pycore_interp.h"
 #endif
 
 typedef struct TraceCallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ test-extras = ["tests-strict", "runtime-strict"]
 # https://cibuildwheel.readthedocs.io/en/stable/options/#archs
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
+[tool.cibuildwheel.windows]
+archs = ['AMD64', 'ARM64']
 
 
 [tool.mypy]


### PR DESCRIPTION
Closes #390... hopefully

- Updated `pyproject.toml::[tool.cibuildwheel.windows]` to also target ARM64. 
- Added corresponding `windows-11-arm` jobs for each `windows-latest` (i.e. x64) CI job in `test_binpy_wheels` where Python version isn't 3.8 (because [`cibuildwheel` doesn't support that](https://cibuildwheel.pypa.io/en/stable/#what-does-it-do))
- Updated `c_trace_callback.h` to only use the `#undef` hacks required on 3.12 when we're actually on 3.12, and only use the `#undef HAVE_STD_ATOMIC` hack on Linux where it is necessary