### PR TITLE
Revert abi3 wheels, which did not work

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,18 +153,6 @@ jobs:
         CIBW_ARCHS_LINUX: ${{ matrix.arch }}
         CIBW_ENVIRONMENT: PYTHONUTF8=1
         PYTHONUTF8: '1'
-        CIBW_CONFIG_SETTINGS: --build-option=--py-limited-api=cp38
-        CIBW_BUILD: cp38-*
-    - name: Build binary wheels
-      uses: pypa/cibuildwheel@v3.1.2
-      with:
-        output-dir: wheelhouse
-        config-file: pyproject.toml
-      env:
-        CIBW_SKIP: ${{ matrix.cibw_skip }}
-        CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-        CIBW_ENVIRONMENT: PYTHONUTF8=1
-        PYTHONUTF8: '1'
     - name: Show built files
       shell: bash
       run: ls -la wheelhouse

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,6 @@ Changes
 5.0.1
 ~~~~~
 * FIX: ref-count leaks #372
-* ENH: Add support for building ABI3 wheels
 * FIX: mitigate speed regressions introduced in 5.0.0
 * ENH: Added capability to combine profiling data both programmatically (``LineStats.__add__()``) and via the CLI (``python -m line_profiler``) (#380, originally proposed in #219)
 * FIX: search function in online documentation

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -18,9 +18,5 @@ if ! which cibuildwheel ; then
     exit 1
 fi
 
-
-# Build ABI3 wheels
-CIBW_CONFIG_SETTINGS="--build-option=--py-limited-api=cp38" CIBW_BUILD="cp38-*" cibuildwheel --config-file pyproject.toml --platform linux --archs x86_64
-
 # Build version-pinned wheels
 cibuildwheel --config-file pyproject.toml --platform linux --archs x86_64


### PR DESCRIPTION
I was hoping adding ABI3 wheels was going to be easy, but the wheels this produces aren't actually ABI3. It looks like we need to make more substantial changes to the Cython/C code to do this properly. 