### PR TITLE
FIX: noisy test in `tests/test_cli.py`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,9 +210,8 @@ def test_multiple_lprof_files(capsys):
     # View them and check the output
     checks = {}
     out, err = capsys.readouterr()
-    with capsys.disabled():
-        print(out, end='')
-        print(err, end='', file=stderr)
+    print(out, end='')
+    print(err, end='', file=stderr)
     for func in sum_n, sum_nsq:
         for comment, n in zip(['Loop', 'Return'], nhits[func]):
             checks[f'  # {comment}: {func.__name__}'] = n


### PR DESCRIPTION
This small patch silences the spurious output ([example](https://github.com/pyutils/line_profiler/actions/runs/18445922214/job/52553364029#step:8:148)) from `tests/test_cli.py::test_multiple_lprof_files` by removing the `capsys.disabled()` context. Now it only spews output when the `-s` switch is passed, as it should.