### PR TITLE
FIX: building Linux-ARM64 wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,9 +140,11 @@ jobs:
       if: ${{ startsWith(matrix.os, 'windows-') }} && ${{ contains(matrix.cibw_skip, '*-win32') }}
       with:
         arch: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
+    # Note: QEMU is needed because we're building for `aarch64` on
+    # `x86_64`
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
-      if: runner.os == 'Linux' && matrix.arch != 'auto'
+      if: runner.os == 'Linux'
       with:
         platforms: all
     - name: Build binary wheels
@@ -152,8 +154,7 @@ jobs:
         config-file: pyproject.toml
       env:
         CIBW_SKIP: ${{ matrix.cibw_skip }}
-        CIBW_TEST_SKIP: '*-win_arm64'
-        CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+        CIBW_TEST_SKIP: '*-win_arm64 *linux_aarch64'
         CIBW_ENVIRONMENT: PYTHONUTF8=1
         PYTHONUTF8: '1'
         VSCMD_ARG_TGT_ARCH: ''
@@ -222,6 +223,10 @@ jobs:
           arch: auto
         - python-version: '3.8'
           install-extras: tests-strict,runtime-strict
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.8'
+          install-extras: tests-strict,runtime-strict
           os: macOS-latest
           arch: auto
         - python-version: '3.8'
@@ -231,6 +236,10 @@ jobs:
         - python-version: '3.13'
           install-extras: tests-strict,runtime-strict,optional-strict
           os: ubuntu-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests-strict,runtime-strict,optional-strict
+          os: ubuntu-24.04-arm
           arch: auto
         - python-version: '3.13'
           install-extras: tests-strict,runtime-strict,optional-strict
@@ -247,6 +256,10 @@ jobs:
         - python-version: '3.13'
           install-extras: tests
           os: ubuntu-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests
+          os: ubuntu-24.04-arm
           arch: auto
         - python-version: '3.13'
           install-extras: tests
@@ -287,6 +300,34 @@ jobs:
         - python-version: '3.14'
           install-extras: tests,optional
           os: ubuntu-latest
+          arch: auto
+        - python-version: '3.8'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.9'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.10'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.12'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
+          arch: auto
+        - python-version: '3.14'
+          install-extras: tests,optional
+          os: ubuntu-24.04-arm
           arch: auto
         - python-version: '3.8'
           install-extras: tests,optional
@@ -368,6 +409,8 @@ jobs:
       if: ${{ startsWith(matrix.os, 'windows-') }}
       with:
         arch: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
+    # Note: Since we're testing Linux wheels on their native
+    # architectures, we don't need QEMU for tests
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       if: runner.os == 'Linux' && matrix.arch != 'auto'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         # explicitly here.
         os:
         - ubuntu-latest
-        # Overhead of building ARM images on Intel Linux nodes is
+        # Overhead of building ARM wheels on Intel Linux nodes is
         # unreasonably high (20s build time per wheel vs 3m);
         # it's better to just spin another runner up to build them
         # natively
@@ -146,7 +146,7 @@ jobs:
       with:
         arch: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
     # Note: Since we're building Linux wheels on their native
-    # architectures, we don't need QEMU for tests
+    # architectures, we don't need QEMU
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       if: runner.os == 'Linux' && matrix.arch != 'auto'
@@ -415,7 +415,7 @@ jobs:
       with:
         arch: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
     # Note: Since we're testing Linux wheels on their native
-    # architectures, we don't need QEMU for tests
+    # architectures, we don't need QEMU
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       if: runner.os == 'Linux' && matrix.arch != 'auto'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,8 +126,8 @@ jobs:
         # explicitly here.
         os:
         - ubuntu-latest
-        - macOS-latest
-        - windows-latest
+        # - macOS-latest
+        # - windows-latest
         cibw_skip:
         - '*-win32 cp3{9,10}-win_arm64 cp313-musllinux_i686'
         arch:
@@ -217,96 +217,96 @@ jobs:
         # Xcookie generates an explicit list of environments that will be used
         # for testing instead of using the more concise matrix notation.
         include:
-        - python-version: '3.8'
-          install-extras: tests-strict,runtime-strict
-          os: ubuntu-latest
-          arch: auto
+        # - python-version: '3.8'
+        #   install-extras: tests-strict,runtime-strict
+        #   os: ubuntu-latest
+        #   arch: auto
         - python-version: '3.8'
           install-extras: tests-strict,runtime-strict
           os: ubuntu-24.04-arm
           arch: auto
-        - python-version: '3.8'
-          install-extras: tests-strict,runtime-strict
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.8'
-          install-extras: tests-strict,runtime-strict
-          os: windows-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: ubuntu-latest
-          arch: auto
+        # - python-version: '3.8'
+        #   install-extras: tests-strict,runtime-strict
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.8'
+        #   install-extras: tests-strict,runtime-strict
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests-strict,runtime-strict,optional-strict
+        #   os: ubuntu-latest
+        #   arch: auto
         - python-version: '3.13'
           install-extras: tests-strict,runtime-strict,optional-strict
           os: ubuntu-24.04-arm
           arch: auto
-        - python-version: '3.13'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: windows-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: windows-11-arm
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests
-          os: ubuntu-latest
-          arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests-strict,runtime-strict,optional-strict
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests-strict,runtime-strict,optional-strict
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests-strict,runtime-strict,optional-strict
+        #   os: windows-11-arm
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests
+        #   os: ubuntu-latest
+        #   arch: auto
         - python-version: '3.13'
           install-extras: tests
           os: ubuntu-24.04-arm
           arch: auto
-        - python-version: '3.13'
-          install-extras: tests
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests
-          os: windows-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests
-          os: windows-11-arm
-          arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests
+        #   os: windows-11-arm
+        #   arch: auto
+        # - python-version: '3.8'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
+        # - python-version: '3.9'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
+        # - python-version: '3.10'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
+        # - python-version: '3.11'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
+        # - python-version: '3.12'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
+        # - python-version: '3.14'
+        #   install-extras: tests,optional
+        #   os: ubuntu-latest
+        #   arch: auto
         - python-version: '3.8'
           install-extras: tests,optional
-          os: ubuntu-latest
+          os: ubuntu-24.04-arm
           arch: auto
         - python-version: '3.9'
           install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.10'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.8'
-          install-extras: tests,optional
-          os: ubuntu-24.04-arm
-          arch: auto
-        - python-version: '3.9'
-          install-extras: tests,optional
           os: ubuntu-24.04-arm
           arch: auto
         - python-version: '3.10'
@@ -329,78 +329,78 @@ jobs:
           install-extras: tests,optional
           os: ubuntu-24.04-arm
           arch: auto
-        - python-version: '3.8'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.9'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.10'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.8'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.9'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.10'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: windows-11-arm
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: windows-11-arm
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: windows-11-arm
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests,optional
-          os: windows-11-arm
-          arch: auto
+        # - python-version: '3.8'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.9'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.10'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.11'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.12'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.14'
+        #   install-extras: tests,optional
+        #   os: macOS-latest
+        #   arch: auto
+        # - python-version: '3.8'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.9'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.10'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.11'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.12'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.14'
+        #   install-extras: tests,optional
+        #   os: windows-latest
+        #   arch: auto
+        # - python-version: '3.11'
+        #   install-extras: tests,optional
+        #   os: windows-11-arm
+        #   arch: auto
+        # - python-version: '3.12'
+        #   install-extras: tests,optional
+        #   os: windows-11-arm
+        #   arch: auto
+        # - python-version: '3.13'
+        #   install-extras: tests,optional
+        #   os: windows-11-arm
+        #   arch: auto
+        # - python-version: '3.14'
+        #   install-extras: tests,optional
+        #   os: windows-11-arm
+        #   arch: auto
     steps:
     - name: Checkout source
       uses: actions/checkout@v4.2.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,12 @@ jobs:
         # the standard [tool.cibuildwheel] section in pyproject.toml and set
         # explicitly here.
         os:
-        - ubuntu-latest
+        # - ubuntu-latest
+        # Overhead of building ARM images on Intel Linux nodes is
+        # unreasonably high (20s build time per wheel vs 3m);
+        # it's better to just spin another runner up to build them
+        # natively
+        - ubuntu-24.04-arm
         # - macOS-latest
         # - windows-latest
         cibw_skip:
@@ -140,11 +145,11 @@ jobs:
       if: ${{ startsWith(matrix.os, 'windows-') }} && ${{ contains(matrix.cibw_skip, '*-win32') }}
       with:
         arch: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
-    # Note: QEMU is needed because we're building for `aarch64` on
-    # `x86_64`
+    # Note: Since we're building Linux wheels on their native
+    # architectures, we don't need QEMU for tests
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.arch != 'auto'
       with:
         platforms: all
     - name: Build binary wheels
@@ -154,7 +159,7 @@ jobs:
         config-file: pyproject.toml
       env:
         CIBW_SKIP: ${{ matrix.cibw_skip }}
-        CIBW_TEST_SKIP: '*-win_arm64 *linux_aarch64'
+        CIBW_TEST_SKIP: '*-win_arm64'
         CIBW_ENVIRONMENT: PYTHONUTF8=1
         PYTHONUTF8: '1'
         VSCMD_ARG_TGT_ARCH: ''

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -246,6 +246,10 @@ jobs:
           arch: auto
         - python-version: '3.13'
           install-extras: tests
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests
           os: macOS-latest
           arch: auto
         - python-version: '3.13'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,14 +125,14 @@ jobs:
         # the standard [tool.cibuildwheel] section in pyproject.toml and set
         # explicitly here.
         os:
-        # - ubuntu-latest
+        - ubuntu-latest
         # Overhead of building ARM images on Intel Linux nodes is
         # unreasonably high (20s build time per wheel vs 3m);
         # it's better to just spin another runner up to build them
         # natively
         - ubuntu-24.04-arm
-        # - macOS-latest
-        # - windows-latest
+        - macOS-latest
+        - windows-latest
         cibw_skip:
         - '*-win32 cp3{9,10}-win_arm64 cp313-musllinux_i686'
         arch:
@@ -222,90 +222,90 @@ jobs:
         # Xcookie generates an explicit list of environments that will be used
         # for testing instead of using the more concise matrix notation.
         include:
-        # - python-version: '3.8'
-        #   install-extras: tests-strict,runtime-strict
-        #   os: ubuntu-latest
-        #   arch: auto
+        - python-version: '3.8'
+          install-extras: tests-strict,runtime-strict
+          os: ubuntu-latest
+          arch: auto
         - python-version: '3.8'
           install-extras: tests-strict,runtime-strict
           os: ubuntu-24.04-arm
           arch: auto
-        # - python-version: '3.8'
-        #   install-extras: tests-strict,runtime-strict
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.8'
-        #   install-extras: tests-strict,runtime-strict
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests-strict,runtime-strict,optional-strict
-        #   os: ubuntu-latest
-        #   arch: auto
+        - python-version: '3.8'
+          install-extras: tests-strict,runtime-strict
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.8'
+          install-extras: tests-strict,runtime-strict
+          os: windows-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests-strict,runtime-strict,optional-strict
+          os: ubuntu-latest
+          arch: auto
         - python-version: '3.13'
           install-extras: tests-strict,runtime-strict,optional-strict
           os: ubuntu-24.04-arm
           arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests-strict,runtime-strict,optional-strict
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests-strict,runtime-strict,optional-strict
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests-strict,runtime-strict,optional-strict
-        #   os: windows-11-arm
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests
-        #   os: ubuntu-latest
-        #   arch: auto
+        - python-version: '3.13'
+          install-extras: tests-strict,runtime-strict,optional-strict
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests-strict,runtime-strict,optional-strict
+          os: windows-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests-strict,runtime-strict,optional-strict
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests
+          os: ubuntu-latest
+          arch: auto
         - python-version: '3.13'
           install-extras: tests
           os: ubuntu-24.04-arm
           arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests
-        #   os: windows-11-arm
-        #   arch: auto
-        # - python-version: '3.8'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
-        # - python-version: '3.9'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
-        # - python-version: '3.10'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
-        # - python-version: '3.11'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
-        # - python-version: '3.12'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
-        # - python-version: '3.14'
-        #   install-extras: tests,optional
-        #   os: ubuntu-latest
-        #   arch: auto
+        - python-version: '3.13'
+          install-extras: tests
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests
+          os: windows-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.8'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.9'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.10'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.12'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
+        - python-version: '3.14'
+          install-extras: tests,optional
+          os: ubuntu-latest
+          arch: auto
         - python-version: '3.8'
           install-extras: tests,optional
           os: ubuntu-24.04-arm
@@ -334,78 +334,78 @@ jobs:
           install-extras: tests,optional
           os: ubuntu-24.04-arm
           arch: auto
-        # - python-version: '3.8'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.9'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.10'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.11'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.12'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.14'
-        #   install-extras: tests,optional
-        #   os: macOS-latest
-        #   arch: auto
-        # - python-version: '3.8'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.9'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.10'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.11'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.12'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.14'
-        #   install-extras: tests,optional
-        #   os: windows-latest
-        #   arch: auto
-        # - python-version: '3.11'
-        #   install-extras: tests,optional
-        #   os: windows-11-arm
-        #   arch: auto
-        # - python-version: '3.12'
-        #   install-extras: tests,optional
-        #   os: windows-11-arm
-        #   arch: auto
-        # - python-version: '3.13'
-        #   install-extras: tests,optional
-        #   os: windows-11-arm
-        #   arch: auto
-        # - python-version: '3.14'
-        #   install-extras: tests,optional
-        #   os: windows-11-arm
-        #   arch: auto
+        - python-version: '3.8'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.9'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.10'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.12'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.14'
+          install-extras: tests,optional
+          os: macOS-latest
+          arch: auto
+        - python-version: '3.8'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.9'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.10'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.12'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.14'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.12'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.13'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
+        - python-version: '3.14'
+          install-extras: tests,optional
+          os: windows-11-arm
+          arch: auto
     steps:
     - name: Checkout source
       uses: actions/checkout@v4.2.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changes
 * FIX: Fixed build on Windows-ARM64 and now building wheels therefor in CI #391
 * FIX: Move away from older, (temporarily-)deprecated ``importlib.resources`` APIs in ``line_profiler.toml_config`` #406
 * CHANGE: remove default alphabetical sorting of profiled functions
+* FIX: Restored building and testing of Linux-ARM64 wheels #402
 
 5.0.0
 ~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ test-extras = ["tests-strict", "runtime-strict"]
 
 # https://cibuildwheel.readthedocs.io/en/stable/options/#archs
 [tool.cibuildwheel.linux]
-# archs = ['x86_64', 'aarch64']
-archs = ['aarch64']
+# We'll build X86 and ARM wheels natively on separate runners
+archs = ['auto']
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ omit =[
 
 [tool.cibuildwheel]
 build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+# XXX: since `tests.yml` already defines `matrix.cibw_skip` for
+# `build_binpy_wheels`, can we deduplicate and just use that?
+# Or do we need these when building wheels for release, which may run on
+# separate pipelines?
 skip = ["*-win32", "cp3{9,10}-win_arm64", "cp313-musllinux_i686"]
 build-frontend = "build"
 build-verbosity = 1
@@ -42,6 +46,8 @@ test-command = "python {project}/run_tests.py"
 test-extras = ["tests-strict", "runtime-strict"]
 
 # https://cibuildwheel.readthedocs.io/en/stable/options/#archs
+[tool.cibuildwheel.linux]
+archs = ['x86_64', 'aarch64']
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ test-extras = ["tests-strict", "runtime-strict"]
 
 # https://cibuildwheel.readthedocs.io/en/stable/options/#archs
 [tool.cibuildwheel.linux]
-archs = ['x86_64', 'aarch64']
+# archs = ['x86_64', 'aarch64']
+archs = ['aarch64']
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
(See also: #390, #391, #394)

Somewhere between [4.1.3](https://github.com/pyutils/line_profiler/releases/tag/v4.1.3) and [5.0.0](https://github.com/pyutils/line_profiler/releases/tag/v5.0.0) we stopped building `linux_aarch64` wheels, perhaps because we bumped the `cibuildwheel` version in #369 which changed its behavior.

This PR updates `pyproject.toml` and `.github/workflows/tests.yml` so that:
- wheels for ARM64 on Linux are again built and tested in CI
- ~~Python 3.14.0rc1 -> 3.14(.0)~~ **EDIT** done in #407