### PR TITLE
FIX: always padding the bytecode of profiled functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Changes
   ``sys.modules['__main__']`` namespace to avoid issues w/e.g. pickling
   (#423)
 * CHANGE: Drop support for Python 3.8 and Python 3.9
+* FIX: Bytecodes of profiled functions now always labeled to prevent
+  confusion with non-profiled "twins" (#425)
 
 
 5.0.2

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -1139,14 +1139,35 @@ datamodel.html#user-defined-functions
         code_hashes = []
         if any(co_code):  # Normal Python functions
             # Figure out how much padding we need and strip the bytecode
+            # Notes:
+            # - Profiled function are always padded, so as to
+            #   distinguish between them and unprofiled bytecode twins
+            # - `npad` is strictly increasing, except when the function
+            #   has already been padded -- we assume that is solely
+            #   because a (could be the same) profiler instance has seen
+            #   it
             base_co_code: bytes
-            npad_code: int
-            base_co_code, npad_code = multibyte_rstrip(co_code)
-            try:
-                npad = self._all_paddings[base_co_code]
-            except KeyError:
-                npad = 0
-            self._all_paddings[base_co_code] = max(npad, npad_code) + 1
+            npad: int
+            is_padded: int
+            base_co_code, is_padded = multibyte_rstrip(co_code)
+            if not is_padded:
+                try:
+                    npad = self._all_paddings[base_co_code]
+                except KeyError:
+                    npad = 1
+                self._all_paddings[base_co_code] = npad + 1
+                # Code hash already exists, so there must be a duplicate
+                # function (on some instance);
+                # (re-)pad with no-op
+                co_code = base_co_code + NOP_BYTES * npad
+                code = _code_replace(func, co_code)
+                try:
+                    func.__code__ = code
+                except AttributeError as e:
+                    func.__func__.__code__ = code
+            # XXX: if we no longer re-pad the bytecode, do we still need
+            # to do bookkeeping on which profiler instances follow which
+            # function objects?
             try:
                 profilers_to_update = self._all_instances_by_funcs[func_id]
                 profilers_to_update.add(self)
@@ -1158,18 +1179,6 @@ datamodel.html#user-defined-functions
                 self.dupes_map[base_co_code].append(code)
             except KeyError:
                 self.dupes_map[base_co_code] = [code]
-            if npad > npad_code:
-                # Code hash already exists, so there must be a duplicate
-                # function (on some instance);
-                # (re-)pad with no-op
-                co_code = base_co_code + NOP_BYTES * npad
-                code = _code_replace(func, co_code)
-                try:
-                    func.__code__ = code
-                except AttributeError as e:
-                    func.__func__.__code__ = code
-            else:  # No re-padding -> no need to update the other profs
-                profilers_to_update = {self}
             # TODO: Since each line can be many bytecodes, this is kinda
             # inefficient
             # See if this can be sped up by not needing to iterate over

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -31,7 +31,6 @@ import opcode
 import os
 import types
 from warnings import warn
-from weakref import WeakSet
 
 from line_profiler._diagnostics import (
     WRAP_TRACE, SET_FRAME_LOCAL_TRACE, USE_LEGACY_TRACE
@@ -1067,9 +1066,6 @@ cdef class LineProfiler:
     _managers = {}
     # type: ClassVar[dict[bytes, int]], bytes = bytecode
     _all_paddings = {}
-    # type: ClassVar[dict[int, weakref.WeakSet[LineProfiler]]],
-    # int = func id
-    _all_instances_by_funcs = {}
 
     def __init__(self, *functions,
                  wrap_trace=None, set_frame_local_trace=None):
@@ -1165,15 +1161,6 @@ datamodel.html#user-defined-functions
                     func.__code__ = code
                 except AttributeError as e:
                     func.__func__.__code__ = code
-            # XXX: if we no longer re-pad the bytecode, do we still need
-            # to do bookkeeping on which profiler instances follow which
-            # function objects?
-            try:
-                profilers_to_update = self._all_instances_by_funcs[func_id]
-                profilers_to_update.add(self)
-            except KeyError:
-                profilers_to_update = WeakSet({self})
-                self._all_instances_by_funcs[func_id] = profilers_to_update
             # Maintain `.dupes_map` (legacy)
             try:
                 self.dupes_map[base_co_code].append(code)
@@ -1213,21 +1200,17 @@ datamodel.html#user-defined-functions
             # because Cython shim code objects don't support local
             # events
             code = code.replace(co_filename=cython_source)
-            profilers_to_update = {self}
         # Update `._c_code_map` and `.code_hash_map` with the new line
-        # hashes on `self` (and other instances profiling the same
-        # function if we padded the bytecode)
-        for instance in profilers_to_update:
-            prof = <LineProfiler>instance
-            try:
-                line_hashes = prof.code_hash_map[code]
-            except KeyError:
-                line_hashes = prof.code_hash_map[code] = []
-            for code_hash in code_hashes:
-                line_hash = <int64>code_hash
-                if not prof._c_code_map.count(line_hash):
-                    line_hashes.append(line_hash)
-                    prof._c_code_map[line_hash]
+        # hashes
+        try:
+            line_hashes = self.code_hash_map[code]
+        except KeyError:
+            line_hashes = self.code_hash_map[code] = []
+        for code_hash in code_hashes:
+            line_hash = <int64>code_hash
+            if not self._c_code_map.count(line_hash):
+                line_hashes.append(line_hash)
+                self._c_code_map[line_hash]
 
         self.functions.append(func)
 

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -7,11 +7,14 @@ import inspect
 import io
 import os
 import pickle
+import subprocess
 import sys
 import textwrap
 import types
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import pytest
+from ubelt import ChDir
 from line_profiler import _line_profiler, LineProfiler, LineStats
 
 
@@ -987,6 +990,94 @@ def test_duplicate_code_objects():
     # (Entries are represented as tuples `(lineno, nhits, time)`)
     (entries,) = profile.get_stats().timings.values()
     assert entries[-2][1] == 10 + 20
+
+
+def test_nonprofiled_clashing_bytecodes(tmp_path_factory):
+    """
+    Test that the profiler can distinguish between a profiled function
+    and a non-profiled one compiling down to the same bytecode.
+    """
+    # See issue #424
+    template = textwrap.dedent("""
+    def {}(n):  # Any function using this compiles to the same bytecode
+        x = 0
+        for n in range(1, n + 1):
+            x += n
+        return x
+    """).strip('\n')
+    module_name = 'my_module'
+    script_name = 'my-script.py'
+    outfile = 'out.lprof'
+    func_p = 'profiled_func'
+    func_no_p = 'nonprofiled_func'
+
+    # Note: bytecode padding depends on the existence of duplicates,
+    # which are counted throughout the lifetime of the `LineProfiler`
+    # class. To ensure that we start on a clean slate -- that
+    # `LineProfiler` isn't "polluted" by running prior tests -- run the
+    # profliing in a subprocess.
+    with ChDir(tmp_path_factory.mktemp('test_nonprofiled_clashing_bytecodes')):
+        syspath_annex = (Path.cwd() / 'syspath').resolve()
+        syspath_annex.mkdir()
+        with (syspath_annex / (module_name + '.py')).open('w') as fobj:
+            print(
+                textwrap.dedent("""
+    '''
+    This docstring is fluff to make the function definitions overlap in
+    line numbers.
+    '''
+
+
+    {fp_def}
+                """).strip('\n').format(fp_def=template.format(func_p)),
+                file=fobj,
+            )
+        with open(script_name, 'w') as fobj:
+            print(
+                textwrap.dedent("""
+    from line_profiler import LineProfiler
+    from {mod} import {fp_name}
+
+
+    {fnp_def}
+
+
+    if __name__ == '__main__':
+        prof = LineProfiler()
+        prof.add_callable({fp_name})
+        with prof:
+            # The context turns on profiling for the call, but it
+            # shouldn't do anything since the imported and profiled
+            # function is not called
+            {fnp_name}(10)
+        prof.dump_stats({out!r})
+                """).strip('\n').format(
+                    mod=module_name,
+                    fp_name=func_p,
+                    fnp_name=func_no_p,
+                    fnp_def=template.format(func_no_p),
+                    out=outfile,
+                ),
+                file=fobj,
+            )
+
+        syspath = os.environ.get('PYTHONPATH', '')
+        syspath = ('{}:{}' if syspath else '{}').format(syspath_annex, syspath)
+        subprocess.run(
+            [sys.executable, script_name],
+            check=True, env={**os.environ, 'PYTHONPATH': syspath},
+        )
+
+        assert os.path.exists(outfile)
+        stats = LineStats.from_files(outfile)
+        stats.print()  # For debugging purposes
+
+    # There should only be one function profiled (`profiled_func()`),
+    # which however doesn't have any actual data because it was never
+    # called
+    ((*_, func_name), data), = stats.timings.items()
+    assert (func_name == func_p), stats
+    assert (not data), stats
 
 
 @pytest.mark.parametrize('force_same_line_numbers', [True, False])

--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -1248,6 +1248,11 @@ def test_aggregate_profiling_data_between_code_versions():
     Test that profiling data from previous versions of the code object
     are preserved when another profiler causes the code object of a
     function to be overwritten.
+
+    Note
+    ----
+    Now obsolete because we no longer double-pad/overwrite the function
+    bytecode if it has already been seen by another profiler instance.
     """
 
     def func(n):
@@ -1262,10 +1267,8 @@ def test_aggregate_profiling_data_between_code_versions():
     # Gather data with `@prof1`
     wrapper1 = prof1(func)
     assert wrapper1(10) == 10 * 11 // 2
-    code = func.__code__
     # Gather data with `@prof2`; the code object is overwritten here
     wrapper2 = prof2(wrapper1)
-    assert func.__code__ != code
     assert wrapper2(15) == 15 * 16 // 2
     # Despite the overwrite of the code object, the old data should
     # still remain, and be aggregated with the new data when calling


### PR DESCRIPTION
Closes #424.

Summary
----
- Function objects touched by profilers are now always bytecode-padded; this is different from the previous behavior of only padding the second function with identical bytecode onwards, circumventing the bug described in #424, where the profiler fails to distinguish between the single profiled function and its non-profiled bytecode "twin".
- The internal logic of `LineProfiler.add_function()` has been streamlined to cut down on the need for bookkeeping, resulting in simpler code and a very slight performance gain.

Code changes
----
- `line_profiler/_line_profiler.pyx::LineProfiler`
  - `._all_instances_by_funcs`  
    Removed this private class attribute; owing to the changes to `.add_function()` as described below, we no longer need to keep tabs on which profiler instance is profiling which function objects
  - `.add_function()`
    - The `.co_code` of the code object of a (normal non-Cython) profiled function is now ALWAYS padded with at least one NOP; this serves to mark profiled functions apart from non-profiled ones which happen to compile down to the same bytecode.
    - If the `.co_code` has already been padded, it is no longer re-padded in the event that multiple profiler instances are profiling the same function.
    - No re-padding also means that the line hashes don't change, so we no longer keep track of other instances profiling the same function objects and update their `.code_hash_map` and `._c_code_map`.

Test changes
----
- `tests/test_line_profiler.py`
  - `test_nonprofiled_clashing_bytecodes()`  
    New test against the edge case described in the issue, making sure that line events from the non-profiled bytecode twin aren't misattributed to the profiled function
  - `test_aggregate_profiling_data_between_code_version()`  
    Updated to no longer check for code-object change after decoration by the second profiler, because again we stopped re-padding bytecodes (#351); note however that this test is now essentially obsolete and maybe we should just remove it...