### PR TITLE
FIX: typing of `ScopingPolicy` members

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changes
   ``sys.modules['__main__']`` namespace to avoid issues w/e.g. pickling
   (#423)
 * CHANGE: Drop support for Python 3.8 and Python 3.9
+* FIX: ``ScopingPolicy`` members now type-check properly as instances
+  thereof -- at least on Python versions (3.11+) where ``enum.StrEnum``
+  is available (#427)
 
 
 5.0.2

--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -600,15 +600,9 @@ class LineProfiler(CLineProfiler, ByCountProfilerMixin):
         namespace: type | types.ModuleType,
         *,
         seen: set[int] | None = None,
-        func_scoping_policy: ScopingPolicy = cast(
-            ScopingPolicy, ScopingPolicy.NONE
-        ),
-        class_scoping_policy: ScopingPolicy = cast(
-            ScopingPolicy, ScopingPolicy.NONE
-        ),
-        module_scoping_policy: ScopingPolicy = cast(
-            ScopingPolicy, ScopingPolicy.NONE
-        ),
+        func_scoping_policy: ScopingPolicy = ScopingPolicy.NONE,
+        class_scoping_policy: ScopingPolicy = ScopingPolicy.NONE,
+        module_scoping_policy: ScopingPolicy = ScopingPolicy.NONE,
         wrap: bool = False,
         name: str | None = None,
     ) -> int:

--- a/line_profiler/line_profiler_utils.py
+++ b/line_profiler/line_profiler_utils.py
@@ -46,7 +46,14 @@ class _StrEnumBase(str, enum.Enum):
         return self.value
 
 
-class StringEnum(getattr(enum, 'StrEnum', _StrEnumBase)):  # type: ignore[misc]
+try:
+    from enum import StrEnum as _StrEnum
+except ImportError:
+    if not typing.TYPE_CHECKING:  # Don't confuse the typechecker
+        _StrEnum = _StrEnumBase
+
+
+class StringEnum(_StrEnum):
     """
     Convenience wrapper around :py:class:`enum.StrEnum`.
 


### PR DESCRIPTION
Closes #426.

- `CHANGELOG.rst`  
  Added entry
- `line_profiler/line_profiler.py::LineProfiler._add_namespace(...)`  
  Removed now-unnecessary `typing.cast()` in default arguments
- `line_profiler/line_profiler_utils.py`
  - `_StrEnum`  
    New alias which resolves:
    - Statically, always to `enum.StrEnum`
    - At the runtime, also thereto if available, and to `_StrEnumBase` otherwise
  - `StringEnum`  
    Now "always" "statically" inheriting from `_StrEnum` to make things less confusing to the type-checker