### PR TITLE
dont destroy type of decorated function

### DIFF
--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -157,7 +157,8 @@ class ProfmodExtractor:
                     tree_index (int):
                         the index of the import as found in the tree
         """
-        module_dict_list = []
+        module_dict_list: list[dict[str, str | int | None]] = []
+        module_dict: dict[str, str | int | None]
         modname_list = []
         for idx, node in enumerate(tree.body):
             if isinstance(node, ast.Import):

--- a/line_profiler/explicit_profiler.py
+++ b/line_profiler/explicit_profiler.py
@@ -171,7 +171,7 @@ import os
 import pathlib
 import sys
 import typing
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, ParamSpec, TypeVar
 
 if typing.TYPE_CHECKING:
     ConfigArg = str | pathlib.PurePath | bool | None
@@ -183,6 +183,8 @@ from .line_profiler import LineProfiler
 from .toml_config import ConfigSource
 
 F = TypeVar('F', bound=Callable[..., Any])
+P = ParamSpec('P')
+R = TypeVar('R')
 
 # The first process that enables profiling records its PID here. Child processes
 # created via multiprocessing (spawn/forkserver) inherit this environment value,
@@ -427,7 +429,7 @@ class GlobalProfiler:
         """
         self.enabled = False
 
-    def __call__(self, func: Callable) -> Callable:
+    def __call__(self, func: Callable[P, R]) -> Callable[P, R]:
         """
         If the global profiler is enabled, decorate a function to start the
         profiler on function entry and stop it on function exit. Otherwise


### PR DESCRIPTION
Would you accept something in this direction? I've been using `line_profiler` a bunch and I noticed that the decorated functions fail linting with `pyright` and the like, because they lose the type.

I didn't setup the tests yet, and we probably have to write it more backwards compatible in case you want it to work with python 3.11 or older.