### PR TITLE
FIX: handling multi-target (from-)import statements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,10 @@ Changes
   confusion with non-profiled "twins" (#425)
 * FIX: Stop reverting ``sys.modules`` after calling ``kernprof.main()``
   to avoid edge-case issues with e.g. pickling (#437)
-* FIX: Fixed bug where ``kernprof -l`` misses ``--prof-mod`` targets if
-  multiple thereof are imported in the same (from-)import statement
-  (#434)
+* FIX: Fixed bugs where ``kernprof -l`` (1) misses ``--prof-mod``
+  targets if multiple thereof are imported in the same (from-)import
+  statement, and (2) crashes when profiling modules containing
+  ``from ... import *`` statements (#434)
 
 
 5.0.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,8 @@ Changes
 * FIX: Stop reverting ``sys.modules`` after calling ``kernprof.main()``
   to avoid edge-case issues with e.g. pickling (#437)
 * FIX: Fixed bug where ``kernprof -l`` misses ``--prof-mod`` targets if
-  multiple thereof are imported in the same (from-)import statement;
-  note however that the return type of
-  ``line_profiler.autoprofile.profmod_extractor.ProfmodExtractor.run()``
-  has changed (#434)
+  multiple thereof are imported in the same (from-)import statement
+  (#434)
 
 
 5.0.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Changes
   confusion with non-profiled "twins" (#425)
 * FIX: Stop reverting ``sys.modules`` after calling ``kernprof.main()``
   to avoid edge-case issues with e.g. pickling (#437)
+* FIX: Fixed bug where ``kernprof -l`` misses ``--prof-mod`` targets if
+  multiple thereof are imported in the same (from-)import statement;
+  note however that the return type of
+  ``line_profiler.autoprofile.profmod_extractor.ProfmodExtractor.run()``
+  has changed (#434)
 
 
 5.0.2

--- a/line_profiler/autoprofile/_import_targets.py
+++ b/line_profiler/autoprofile/_import_targets.py
@@ -1,0 +1,184 @@
+import ast
+import dataclasses
+from collections.abc import Collection, Sequence
+from itertools import groupby
+from operator import attrgetter
+from typing import Any
+from typing_extensions import Self
+from warnings import warn
+
+from .. import _diagnostics as diagnostics
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class ImportTarget:
+    """
+    An import target.
+
+    Init attrs:
+        name (str):
+            The real name of the import. e.g. ``import foo as bar``
+            -> ``'foo'``
+
+        index (int):
+            The index of the import as found in the AST body
+
+        alias (str | None):
+            The alias of an import if applicable. e.g.:
+
+            - ``import foo as bar`` -> ``'bar'``
+            - ``import foo`` -> ``None``
+
+        lineno (int | None):
+            Optional (1-indexed) line number on which the import occurs.
+
+    Other attrs:
+        resolved_name (str | None):
+            Name under which the import can be found, e.g.:
+
+            - ``import foo as bar`` -> ``'bar'``
+            - ``import foo`` -> ``'foo'``
+            - ``from foo import *`` -> ``None``
+
+    Note:
+        Other than the above attributes, the remaining attributes and
+        methods of this object should be considered private.
+    """
+    name: str
+    index: int
+    alias: str | None = None
+    lineno: int | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Type verifications.
+        """
+        if not isinstance(self.name, str):
+            raise TypeError(f'.name = {self.name!r}: expected a str')
+        if not isinstance(self.index, int):
+            raise TypeError(
+                f'.index = {self.index!r}: expected an int',
+            )
+        if not (self.alias is None or isinstance(self.alias, str)):
+            raise TypeError(f'.alias = {self.alias!r}: expected a str or None')
+        if not (self.lineno is None or isinstance(self.lineno, int)):
+            raise TypeError(
+                f'.lineno = {self.lineno!r}: expected an int or None',
+            )
+
+    @classmethod
+    def _from_ast_nodes(cls, nodes: Sequence[ast.AST]) -> list[Self]:
+        """
+        Get all imports in the body of an AST node.
+
+        Args:
+            nodes (Sequence[ast.AST]):
+                AST nodes to scan for imports;
+                examples: :py:attr:`ast.Module.body`,
+                :py:attr:`ast.If.orelse`.
+
+        Returns:
+            import_targets (list[Self]):
+                List of all imports amond the nodes.
+
+        Notes:
+            Imports nested inside the ``nodes`` are not as yet
+            handled, e.g. in
+
+            >>> # doctest: +SKIP
+            >>> from spam import ham
+            >>> try:
+            ...     from some_foo import bar
+            ... except ImportError:
+            ...     from other_foo import ersatz_bar as bar
+
+            Only ``ham`` is extracted but not ``bar``.
+        """
+        targets: list[Self] = []
+        modnames: set[str] = set()
+        for index, node in enumerate(nodes):
+            if isinstance(node, ast.Import):
+                new_targets: list[Self] = cls._from_import_node(index, node)
+            elif isinstance(node, ast.ImportFrom):
+                new_targets = cls._from_import_from_node(index, node)
+            else:  # TODO: descend into other bodied nodes
+                new_targets = []
+            for target in new_targets:
+                if target.name not in modnames:
+                    targets.append(target)
+                    modnames.add(target.name)
+        return targets
+
+    @classmethod
+    def _from_import_node(cls, index: int, node: ast.Import) -> list[Self]:
+        return [
+            cls(name.name, index, name.asname, name.lineno)
+            for name in node.names
+        ]
+
+    @classmethod
+    def _from_import_from_node(
+        cls, index: int, node: ast.ImportFrom,
+    ) -> list[Self]:
+        if node.module is None:  # `from . import ...`
+            return []
+        return [
+            cls(
+                f'{node.module}.{name.name}',
+                index,
+                name.asname or name.name,
+                name.lineno,
+            )
+            for name in node.names
+        ]
+
+    def _get_target_repr(self) -> str:
+        if self.alias == '*':
+            assert self.name.endswith('.*')
+            return f'* (from {self.name[:-2]})'
+        elif self.alias:
+            return f'{self.alias} (= {self.name})'
+        else:
+            return self.name
+
+    @classmethod
+    def _check_and_warn_dropped_imports(
+        cls,
+        imports: Collection[Self],
+        reason: str,
+        source: Any,
+        category: type[Warning] = UserWarning,
+        stacklevel: int = 1,
+        *args,
+        **kwargs
+    ) -> None:
+        if not imports:
+            return
+        msg_chunks: list[str] = [
+            '{}: {} would-be profiling target(s) dropped because {}:'
+            .format(source, len(imports), reason),
+        ]
+        imports = sorted(imports, key=lambda imp: imp.lineno or float('inf'))
+        for lineno, imports_on_line in groupby(
+            imports, key=attrgetter('lineno'),
+        ):
+            lineno_repr = '???' if lineno is None else str(lineno)
+            targets = ', '.join(sorted(
+                imp._get_target_repr() for imp in imports_on_line
+            ))
+            msg_chunks.append(f'- line {lineno_repr}: {targets}')
+        msg = (' ' if len(msg_chunks) < 3 else '\n').join(msg_chunks)
+        if category is None:
+            log_msg = msg
+        else:
+            log_msg = f'{category.__name__}: {msg}'
+        diagnostics.log.warning(log_msg)
+        warn(msg, category, stacklevel + 1, *args, **kwargs)
+
+    @property
+    def resolved_name(self) -> str | None:
+        # Note: star-imports are parsed into
+        # `ImportTarget('module.name.*', index, '*', lineno)`
+        if self.alias == '*':
+            return None
+        return self.alias or self.name

--- a/line_profiler/autoprofile/ast_profile_transformer.py
+++ b/line_profiler/autoprofile/ast_profile_transformer.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import ast
-from typing import cast, Union, List
+from collections.abc import Callable, Sequence
+from functools import partial
+from os import PathLike
+from typing import cast, TypeVar
+
+from ._import_targets import ImportTarget
+
+
+_Import = TypeVar('_Import', ast.Import, ast.ImportFrom)
 
 
 def ast_create_profile_node(
@@ -80,6 +88,7 @@ class AstProfileTransformer(ast.NodeTransformer):
             profiled_imports if profiled_imports is not None else []
         )
         self._profiler_name = profiler_name
+        self._dropped_star_imports: set[ImportTarget] = set()
 
     def _visit_func_def(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef
@@ -113,12 +122,10 @@ class AstProfileTransformer(ast.NodeTransformer):
     visit_FunctionDef = visit_AsyncFunctionDef = _visit_func_def
 
     def _visit_import(
-        self, node: ast.Import | ast.ImportFrom
-    ) -> (
-        ast.Import
-        | ast.ImportFrom
-        | list[ast.Import | ast.ImportFrom | ast.Expr]
-    ):
+        self,
+        node: _Import,
+        get_import_targets: Callable[[_Import], Sequence[ImportTarget]],
+    ) -> _Import | list[_Import | ast.Expr]:
         """Add a node that profiles an import
 
         If profile_imports is True and the import is not in profiled_imports,
@@ -139,12 +146,16 @@ class AstProfileTransformer(ast.NodeTransformer):
         if not self._profile_imports:
             self.generic_visit(node)
             return node
-        this_visit = cast(
-            Union[ast.Import, ast.ImportFrom], self.generic_visit(node)
-        )
-        visited: list[ast.Import | ast.ImportFrom | ast.Expr] = [this_visit]
-        for names in node.names:
-            node_name = names.name if names.asname is None else names.asname
+        this_visit = cast(_Import, self.generic_visit(node))
+        visited: list[_Import | ast.Expr] = [this_visit]
+        for name, target in zip(
+            node.names, get_import_targets(node), strict=True,
+        ):
+            node_name = name.name if name.asname is None else name.asname
+            if target.resolved_name is None:
+                # TODO: handle starred imports
+                self._dropped_star_imports.add(target)
+                continue
             if node_name in self._profiled_imports:
                 continue
             self._profiled_imports.append(node_name)
@@ -168,10 +179,11 @@ class AstProfileTransformer(ast.NodeTransformer):
                 if profile_imports is True:
                     returns list containing the import node and the profiling node
         """
-        return cast(
-            Union[ast.Import, List[Union[ast.Import, ast.Expr]]],
-            self._visit_import(node),
-        )
+        # Note: we don't actually care about the `ImportTarget.index`
+        # here; in fact, we're just reusing the name-resolution
+        # machinery in `ImportTarget`
+        get_targets = partial(ImportTarget._from_import_node, 0)
+        return self._visit_import(node, get_targets)
 
     def visit_ImportFrom(
         self, node: ast.ImportFrom
@@ -189,7 +201,41 @@ class AstProfileTransformer(ast.NodeTransformer):
                 if profile_imports is True:
                     returns list containing the import node and the profiling node
         """
-        return cast(
-            Union[ast.ImportFrom, List[Union[ast.ImportFrom, ast.Expr]]],
-            self._visit_import(node),
-        )
+        get_targets = partial(ImportTarget._from_import_from_node, 0)
+        return self._visit_import(node, get_targets)
+
+    @classmethod
+    def _transform(
+        cls,
+        node: ast.Module,
+        filename: PathLike[str] | str | None = None,
+        **kwargs,
+    ) -> ast.Module:
+        """
+        Wrapper around ``<instance>.visit()`` with extra bookkeeping.
+
+        Args:
+            node (ast.Module):
+                AST module node
+            filename (PathLike[str] | str | None):
+                Optional filename to be used in error/warning messages
+            **kwargs
+                Passed to the initializer
+
+        Returns:
+            node (ast.Module):
+                Input module node
+        """
+        transformer = cls(**kwargs)
+        dropped_star_imports = transformer._dropped_star_imports
+        if filename is None:
+            filename = '???'
+        try:
+            return transformer.visit(node)
+        finally:
+            ImportTarget._check_and_warn_dropped_imports(
+                dropped_star_imports,
+                "we don't currently handle `from ... import *` statements",
+                filename,
+                stacklevel=2,  # Attribute warning to the caller
+            )

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -106,7 +106,7 @@ class AstTreeProfiler:
     def _profile_ast_tree(
         self,
         tree: ast.Module,
-        tree_imports_to_profile_dict: dict[int, str],
+        tree_imports_to_profile_dict: dict[int, list[str]],
         profile_full_script: bool = False,
         profile_imports: bool = False,
     ) -> ast.Module:
@@ -122,12 +122,13 @@ class AstTreeProfiler:
             tree (_ast.Module):
                 abstract syntax tree to be profiled.
 
-            tree_imports_to_profile_dict (Dict[int,str]):
+            tree_imports_to_profile_dict (dict[int, list[str]]):
                 dict of imports to profile
                     key (int):
                         index of import in AST
-                    value (str):
-                        alias (or name if no alias used) of import
+                    value (list[str]):
+                        list of aliases (or names if no alias used) to
+                        import
 
             profile_full_script (bool):
                 if True, profile whole script.
@@ -144,10 +145,13 @@ class AstTreeProfiler:
             list(tree_imports_to_profile_dict), reverse=True
         )
         for tree_index in argsort_tree_indexes:
-            name = tree_imports_to_profile_dict[tree_index]
-            expr = ast_create_profile_node(name)
-            tree.body.insert(tree_index + 1, expr)
-            profiled_imports.append(name)
+            names = tree_imports_to_profile_dict[tree_index]
+            for name in reversed(names):
+                # Reversing keeps the order of the inserted nodes
+                # consistent with the imports
+                expr = ast_create_profile_node(name)
+                tree.body.insert(tree_index + 1, expr)
+                profiled_imports.append(name)
         if profile_full_script:
             tree = self._ast_transformer_class_handler(
                 profile_imports=profile_imports,

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import os
-from typing import Type
 
 from .ast_profile_transformer import (
     AstProfileTransformer,
@@ -29,8 +28,12 @@ class AstTreeProfiler:
         script_file: str,
         prof_mod: list[str],
         profile_imports: bool,
-        ast_transformer_class_handler: Type = AstProfileTransformer,
-        profmod_extractor_class_handler: Type = ProfmodExtractor,
+        ast_transformer_class_handler: (
+            type[AstProfileTransformer]
+        ) = AstProfileTransformer,
+        profmod_extractor_class_handler: (
+            type[ProfmodExtractor]
+        ) = ProfmodExtractor,
     ) -> None:
         """Initializes the AST tree profiler instance with the script file path
 
@@ -46,10 +49,10 @@ class AstTreeProfiler:
             profile_imports (bool):
                 if True, when auto-profiling whole script, profile all imports aswell.
 
-            ast_transformer_class_handler (Type):
+            ast_transformer_class_handler (type[AstProfileTransformer]):
                 the AstProfileTransformer class that handles profiling the whole script.
 
-            profmod_extractor_class_handler (Type):
+            profmod_extractor_class_handler (type[ProfmodExtractor]):
                 the ProfmodExtractor class that handles mapping prof_mod to objects in the script.
         """
         self._script_file = script_file
@@ -183,7 +186,7 @@ class AstTreeProfiler:
 
         tree_imports_to_profile_dict = self._profmod_extractor_class_handler(
             tree, self._script_file, self._prof_mod
-        ).run()
+        ).run(assume_single_target_imports=False)
         tree_profiled = self._profile_ast_tree(
             tree,
             tree_imports_to_profile_dict,

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -135,7 +135,7 @@ class AstTreeProfiler:
                 abstract syntax tree to be profiled.
 
             tree_imports_to_profile_dict (dict[tuple[str | int, ...], \
-list[str]]):
+list[ImportTarget]]):
                 dict of imports to profile
                     key (tuple[str | int, ...]):
                         Location of import in AST, e.g. ``('body', 0)``

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -177,10 +177,11 @@ list[str]]):
                 body.insert(tree_index + 1, expr)
                 profiled_imports.append(name)
         if profile_full_script:
-            tree = self._ast_transformer_class_handler(
+            tree = self._ast_transformer_class_handler._transform(
+                tree, self._script_file,
                 profile_imports=profile_imports,
                 profiled_imports=profiled_imports,
-            ).visit(tree)
+            )
         ast.fix_missing_locations(tree)
         return tree
 

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import ast
 import os
+from collections.abc import MutableSequence, Sequence
+from typing import Any
 
 from .ast_profile_transformer import (
     AstProfileTransformer,
     ast_create_profile_node,
 )
-from .profmod_extractor import ProfmodExtractor
+from .profmod_extractor import ImportTarget, ProfmodExtractor
 
 __docstubs__ = """
 from .ast_profile_transformer import AstProfileTransformer
@@ -109,35 +111,46 @@ class AstTreeProfiler:
     def _profile_ast_tree(
         self,
         tree: ast.Module,
-        tree_imports_to_profile_dict: dict[int, list[str]],
+        tree_imports_to_profile_dict: dict[
+            tuple[str | int, ...], list[ImportTarget]
+        ],
         profile_full_script: bool = False,
         profile_imports: bool = False,
     ) -> ast.Module:
-        """Add profiling to an abstract syntax tree.
+        """
+        Add profiling to an abstract syntax tree by adding nodes to the
+        AST that adds the specified objects to the profiler.
 
-        Adds nodes to the AST that adds the specified objects to the profiler.
-        If profile_full_script is True, all functions/methods, classes & modules in the script
-        have a node added to the AST to add them to the profiler.
-        If profile_imports is True as well as profile_full_script, all imports are have a node
-        added to the AST to add them to the profiler.
+        - If ``profile_full_script`` is True, all functions/methods,
+          classes & modules in the script have a node added to the AST
+          to add them to the profiler.
+
+        - If ``profile_imports ``is True as well as
+          ``profile_full_script``, all imports are have a node added to
+          the AST to add them to the profiler.
 
         Args:
             tree (_ast.Module):
                 abstract syntax tree to be profiled.
 
-            tree_imports_to_profile_dict (dict[int, list[str]]):
+            tree_imports_to_profile_dict (dict[tuple[str | int, ...], \
+list[str]]):
                 dict of imports to profile
-                    key (int):
-                        index of import in AST
-                    value (list[str]):
-                        list of aliases (or names if no alias used) to
-                        import
+                    key (tuple[str | int, ...]):
+                        Location of import in AST, e.g. ``('body', 0)``
+                        for the case where it is the first statement in
+                        the :py:attr:`ast.Module.body`
+                    value (list[ImportTarget]):
+                        list of import targets (see the documentation of
+                        :py:class:`line_profiler.autoprofile\
+.profmod_extractor.ImportTarget`)
 
             profile_full_script (bool):
-                if True, profile whole script.
+                if True, profile the entire script.
 
             profile_imports (bool):
-                if True, and profile_full_script is True, profile all imports aswell.
+                if True, and ``profile_full_script`` is True, profile
+                all imports as well.
 
         Returns:
             (_ast.Module): tree
@@ -147,13 +160,20 @@ class AstTreeProfiler:
         argsort_tree_indexes = sorted(
             list(tree_imports_to_profile_dict), reverse=True
         )
-        for tree_index in argsort_tree_indexes:
-            names = tree_imports_to_profile_dict[tree_index]
-            for name in reversed(names):
+        for tree_loc in argsort_tree_indexes:
+            imports = tree_imports_to_profile_dict[tree_loc]
+            *loc, tree_index = tree_loc
+            assert isinstance(tree_index, int)
+            body = self._descend(tree, loc)
+            assert isinstance(body, MutableSequence)
+            for imp in reversed(imports):
                 # Reversing keeps the order of the inserted nodes
                 # consistent with the imports
+                name = imp.resolved_name
+                if name is None:  # Star-imports; TODO: handle this
+                    continue
                 expr = ast_create_profile_node(name)
-                tree.body.insert(tree_index + 1, expr)
+                body.insert(tree_index + 1, expr)
                 profiled_imports.append(name)
         if profile_full_script:
             tree = self._ast_transformer_class_handler(
@@ -194,3 +214,28 @@ class AstTreeProfiler:
             profile_imports=self._profile_imports,
         )
         return tree_profiled
+
+    @staticmethod
+    def _descend(obj: Any, loc: Sequence[str | int]) -> Any:
+        """
+        Follow ``loc``, a sequence of indices (item access) and names
+        (attribute access), to descend into an object.
+
+        Examples:
+            >>> from types import SimpleNamespace as ns
+
+            >>> my_ns = ns(
+            ...     foo={1: 2, 3: ['foo', 'bar']},
+            ...     bar=[ns(spam=1), ns(ham=[1, 2], eggs=None)]
+            ... )
+            >>> AstTreeProfiler._descend(my_ns, ['foo', 3, 1, 2])
+            'r'
+            >>> AstTreeProfiler._descend(my_ns, ['bar', 1, 'ham', 0])
+            1
+        """
+        for index_or_attr in loc:
+            if isinstance(index_or_attr, int):
+                obj = obj[index_or_attr]
+            else:  # Attribute name
+                obj = getattr(obj, index_or_attr)
+        return obj

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -186,7 +186,7 @@ class AstTreeProfiler:
 
         tree_imports_to_profile_dict = self._profmod_extractor_class_handler(
             tree, self._script_file, self._prof_mod
-        ).run(assume_single_target_imports=False)
+        ).extract_all()
         tree_profiled = self._profile_ast_tree(
             tree,
             tree_imports_to_profile_dict,

--- a/line_profiler/autoprofile/ast_tree_profiler.py
+++ b/line_profiler/autoprofile/ast_tree_profiler.py
@@ -5,11 +5,12 @@ import os
 from collections.abc import MutableSequence, Sequence
 from typing import Any
 
+from ._import_targets import ImportTarget
 from .ast_profile_transformer import (
     AstProfileTransformer,
     ast_create_profile_node,
 )
-from .profmod_extractor import ImportTarget, ProfmodExtractor
+from .profmod_extractor import ProfmodExtractor
 
 __docstubs__ = """
 from .ast_profile_transformer import AstProfileTransformer

--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import ast
 import os
 import sys
-from typing import cast
+from typing import Literal, cast, overload
+from warnings import warn
 from .util_static import (
     modname_to_modpath,
     modpath_to_modname,
     package_modpaths,
 )
+from .. import _diagnostics as diagnostics
 
 
 class ProfmodExtractor:
@@ -244,27 +246,92 @@ class ProfmodExtractor:
             modnames_found_in_tree.setdefault(tree_index, []).append(name)
         return modnames_found_in_tree
 
-    def run(self) -> dict[int, list[str]]:
+    @overload
+    def run(
+        self, *, assume_single_target_imports: Literal[True] = True,
+    ) -> dict[int, str]:
+        ...
+
+    @overload
+    def run(
+        self, *, assume_single_target_imports: Literal[False],
+    ) -> dict[int, list[str]]:
+        ...
+
+    def run(
+        self, *, assume_single_target_imports: bool = True,
+    ) -> dict[int, str] | dict[int, list[str]]:
         """Map prof_mod to imports in an abstract syntax tree.
 
-        Takes the paths and dotted paths in prod_mod and finds their respective imports in an
+        Takes the paths and dotted paths in prof_mod and finds their respective imports in an
         abstract syntax tree, returning their alias and the index they appear in the AST.
 
+        Args:
+            assume_single_target_imports (bool):
+                If true, return ``dict[int, str]``, consistent to legacy
+                behavior where only the last import target in a
+                multi-target (from-)import statement will be profiled;
+                otherwise, return ``dict[int, list[str]]``
+
         Returns:
-            tree_imports_to_profile_dict (dict[int, list[str]]);
+            tree_imports_to_profile_dict (dict[int, str] | dict[int, list[str]]);
                 dict of imports to profile
                     key (int):
                         index of import in AST
-                    value (list[str]):
+                    value (str | list[str]):
                         list of aliases (or names if no alias used) to
-                        import
+                        import;
+                        if ``assume_single_target_imports=True``, only
+                        the last name in an import statement is reported
+
+        Warning:
+            ``assume_single_target_imports=True`` results in a
+            :py:class:`DeprecationWarning`, and an additional
+            warning if any potential ``prof_mod`` target is dropped from
+            being profiled.
         """
+        def issue_warning(
+            msg: str, category: type[Warning] | None = None, *args, **kwargs,
+        ) -> None:
+            if category is None:
+                log_msg = msg
+            else:
+                log_msg = f'{category.__name__}: {msg}'
+            diagnostics.log.warning(log_msg)
+            warn(msg, category, *args, **kwargs)
+
         modnames_to_profile = self._get_modnames_to_profile_from_prof_mod(
             self._script_file, self._prof_mod
         )
 
         module_dict_list = self._ast_get_imports_from_tree(self._tree)
 
-        return self._find_modnames_in_tree_imports(
+        tree_imports_to_profile_dict = self._find_modnames_in_tree_imports(
             modnames_to_profile, module_dict_list
         )
+        if not assume_single_target_imports:
+            return tree_imports_to_profile_dict
+        msg = (
+            'Invoking `ProfmodExtractor.run()` directly is now deprecated, '
+            'because it returns a `dict[int, str]` and cannot handle '
+            'multi-target import statements; '
+            'pass `assume_single_target_imports=False` to return a '
+            '`dict[int, list[str]]` and avoid this warning'
+        )
+        issue_warning(msg, DeprecationWarning, stacklevel=2)
+        conflated_result: dict[int, str] = {}
+        dropped_names: set[str] = set()
+        for i, names in tree_imports_to_profile_dict.items():
+            *remainder, last = names
+            dropped_names.update(remainder)
+            conflated_result[i] = last
+        dropped_names -= set(conflated_result.values())
+        if dropped_names:
+            msg = (
+                '{}: {} would-be profiling target(s) dropped because the '
+                'import statement(s) are multi-target: {!r}'
+            ).format(
+                self._script_file, len(dropped_names), sorted(dropped_names),
+            )
+            issue_warning(msg, stacklevel=2)
+        return conflated_result

--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 import os
 import sys
-from typing import List, cast, Any, Union
+from typing import cast
 from .util_static import (
     modname_to_modpath,
     modpath_to_modname,
@@ -30,7 +30,7 @@ class ProfmodExtractor:
             script_file (str):
                 path to script being profiled.
 
-            prof_mod (List[str]):
+            prof_mod (list[str]):
                 list of imports to profile in script.
                 passing the path to script will profile the whole script.
                 the objects can be specified using its dotted path or full path (if applicable).
@@ -77,13 +77,13 @@ class ProfmodExtractor:
             script_file (str):
                 path to script being profiled.
 
-            prof_mod (List[str]):
+            prof_mod (list[str]):
                 list of imports to profile in script.
                 passing the path to script will profile the whole script.
                 the objects can be specified using its dotted path or full path (if applicable).
 
         Returns:
-            modnames_to_profile (List[str]):
+            modnames_to_profile (list[str]):
                 list of dotted paths to profile.
         """
         script_directory = os.path.realpath(os.path.dirname(script_file))
@@ -105,7 +105,7 @@ class ProfmodExtractor:
             so we check if the item is path and whether that path exists, else skip the item.
             """
             modpath = modname_to_modpath(
-                mod, sys_path=cast(List[Union[str, os.PathLike]], new_sys_path)
+                mod, sys_path=cast('list[str | os.PathLike]', new_sys_path)
             )
             if modpath is None:
                 """if cannot convert to modpath, check if already path and if invalid"""
@@ -148,7 +148,7 @@ class ProfmodExtractor:
                 abstract syntax tree to fetch imports from.
 
         Returns:
-            module_dict_list (List[Dict[str,Union[str,int]]]):
+            module_dict_list (list[Dict[str, str | int]]):
                 list of dicts of all imports in the tree, containing:
                     name (str):
                         the real name of the import. e.g. foo from "import foo as bar"
@@ -193,7 +193,7 @@ class ProfmodExtractor:
     def _find_modnames_in_tree_imports(
         modnames_to_profile: list[str],
         module_dict_list: list[dict[str, str | int | None]],
-    ) -> dict[int, str]:
+    ) -> dict[int, list[str]]:
         """Map modnames to imports from an abstract sytax tree.
 
         Find imports in modue_dict_list, created from an abstract syntax tree, that match
@@ -205,21 +205,22 @@ class ProfmodExtractor:
         The import's alias is stored in the output dict.
 
         Args:
-            modnames_to_profile (List[str]):
+            modnames_to_profile (list[str]):
                 list of dotted paths to profile.
 
-            module_dict_list (List[Dict[str,Union[str,int]]]):
+            module_dict_list (list[Dict[str, str | int]]):
                 list of dicts of all imports in the tree.
 
         Returns:
-            modnames_found_in_tree (Dict[int,str]):
+            modnames_found_in_tree (dict[int, list[str]]):
                 dict of imports found
                     key (int):
-                        index of import in AST
-                    value (str):
-                        alias (or name if no alias used) of import
+                        index of the (from-)import statement in AST
+                    value (list[str]):
+                        list of aliases (or names if no alias used) to
+                        import
         """
-        modnames_found_in_tree: dict[int, str] = {}
+        modnames_found_in_tree: dict[int, list[str]] = {}
         modname_added_list = []
         for i, module_dict in enumerate(module_dict_list):
             modname = module_dict['name']
@@ -240,22 +241,23 @@ class ProfmodExtractor:
             tree_index = module_dict['tree_index']
             if not isinstance(tree_index, int):
                 raise TypeError('should have gotten an int')
-            modnames_found_in_tree[tree_index] = name
+            modnames_found_in_tree.setdefault(tree_index, []).append(name)
         return modnames_found_in_tree
 
-    def run(self) -> dict[int, str]:
+    def run(self) -> dict[int, list[str]]:
         """Map prof_mod to imports in an abstract syntax tree.
 
         Takes the paths and dotted paths in prod_mod and finds their respective imports in an
         abstract syntax tree, returning their alias and the index they appear in the AST.
 
         Returns:
-            (Dict[int,str]): tree_imports_to_profile_dict
+            tree_imports_to_profile_dict (dict[int, list[str]]);
                 dict of imports to profile
                     key (int):
                         index of import in AST
-                    value (str):
-                        alias (or name if no alias used) of import
+                    value (list[str]):
+                        list of aliases (or names if no alias used) to
+                        import
         """
         modnames_to_profile = self._get_modnames_to_profile_from_prof_mod(
             self._script_file, self._prof_mod
@@ -263,7 +265,6 @@ class ProfmodExtractor:
 
         module_dict_list = self._ast_get_imports_from_tree(self._tree)
 
-        tree_imports_to_profile_dict = self._find_modnames_in_tree_imports(
+        return self._find_modnames_in_tree_imports(
             modnames_to_profile, module_dict_list
         )
-        return tree_imports_to_profile_dict

--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 import os
 import sys
-from typing import Literal, cast, overload
+from typing import Literal, cast
 from warnings import warn
 from .util_static import (
     modname_to_modpath,
@@ -246,32 +246,11 @@ class ProfmodExtractor:
             modnames_found_in_tree.setdefault(tree_index, []).append(name)
         return modnames_found_in_tree
 
-    @overload
-    def run(
-        self, *, assume_single_target_imports: Literal[True] = True,
-    ) -> dict[int, str]:
-        ...
-
-    @overload
-    def run(
-        self, *, assume_single_target_imports: Literal[False],
-    ) -> dict[int, list[str]]:
-        ...
-
-    def run(
-        self, *, assume_single_target_imports: bool = True,
-    ) -> dict[int, str] | dict[int, list[str]]:
+    def extract_all(self) -> dict[int, list[str]]:
         """Map prof_mod to imports in an abstract syntax tree.
 
         Takes the paths and dotted paths in prof_mod and finds their respective imports in an
-        abstract syntax tree, returning their alias and the index they appear in the AST.
-
-        Args:
-            assume_single_target_imports (bool):
-                If true, return ``dict[int, str]``, consistent to legacy
-                behavior where only the last import target in a
-                multi-target (from-)import statement will be profiled;
-                otherwise, return ``dict[int, list[str]]``
+        abstract syntax tree, returning their aliases and the index they appear in the AST.
 
         Returns:
             tree_imports_to_profile_dict (dict[int, str] | dict[int, list[str]]);
@@ -280,52 +259,60 @@ class ProfmodExtractor:
                         index of import in AST
                     value (str | list[str]):
                         list of aliases (or names if no alias used) to
-                        import;
-                        if ``assume_single_target_imports=True``, only
-                        the last name in an import statement is reported
-
-        Warning:
-            ``assume_single_target_imports=True`` results in a
-            :py:class:`DeprecationWarning`, and an additional
-            warning if any potential ``prof_mod`` target is dropped from
-            being profiled.
+                        import
         """
-        def issue_warning(
-            msg: str, category: type[Warning] | None = None, *args, **kwargs,
-        ) -> None:
-            if category is None:
-                log_msg = msg
-            else:
-                log_msg = f'{category.__name__}: {msg}'
-            diagnostics.log.warning(log_msg)
-            warn(msg, category, *args, **kwargs)
-
         modnames_to_profile = self._get_modnames_to_profile_from_prof_mod(
             self._script_file, self._prof_mod
         )
 
         module_dict_list = self._ast_get_imports_from_tree(self._tree)
 
-        tree_imports_to_profile_dict = self._find_modnames_in_tree_imports(
-            modnames_to_profile, module_dict_list
+        return self._find_modnames_in_tree_imports(
+            modnames_to_profile, module_dict_list,
         )
-        if not assume_single_target_imports:
-            return tree_imports_to_profile_dict
+
+    def run(self) -> dict[int, str]:
+        """
+        Deprecated, legacy method kept for backward compatibility.
+
+        Returns:
+            tree_imports_to_profile_dict (dict[int, str])
+                dict of imports to profile
+                    key (int):
+                        index of import in AST
+                    value (str):
+                        alias (or name if no alias used) of the LAST
+                        target to import in the corresponding
+                        :py:class:`ast.Import` or
+                        :py:class:`ast.ImportFrom` statement
+
+        Notes:
+            - New code should use the :py:meth:`.extract_all` method,
+              which handles multi-target import statements (see #434).
+
+            - Calling this method issues a
+              :py:class:`DeprecationWarning`.
+
+            - For multi-target import statements, this only preserves
+              the last target. If this results in import targets being
+              dropped, a :py:class:`UserWarning` is issued.
+        """
         msg = (
-            'Invoking `ProfmodExtractor.run()` directly is now deprecated, '
-            'because it returns a `dict[int, str]` and cannot handle '
-            'multi-target import statements; '
-            'pass `assume_single_target_imports=False` to return a '
-            '`dict[int, list[str]]` and avoid this warning'
+            '`ProfmodExtractor.run()` is now deprecated, because it cannot '
+            'correctly resolve multi-target import statements; '
+            'use `ProfmodExtractor.extract_all()` instead.'
         )
-        issue_warning(msg, DeprecationWarning, stacklevel=2)
-        conflated_result: dict[int, str] = {}
+        _issue_warning(msg, DeprecationWarning, stacklevel=2)
+        result: dict[int, str] = {}
         dropped_names: set[str] = set()
-        for i, names in tree_imports_to_profile_dict.items():
+        for i, names in self.extract_all().items():
             *remainder, last = names
             dropped_names.update(remainder)
-            conflated_result[i] = last
-        dropped_names -= set(conflated_result.values())
+            # In case a later import shadows a dropped name from an
+            # earlier import
+            dropped_names.discard(last)
+            result[i] = last
+        dropped_names -= set(result.values())
         if dropped_names:
             msg = (
                 '{}: {} would-be profiling target(s) dropped because the '
@@ -333,5 +320,20 @@ class ProfmodExtractor:
             ).format(
                 self._script_file, len(dropped_names), sorted(dropped_names),
             )
-            issue_warning(msg, stacklevel=2)
-        return conflated_result
+            _issue_warning(msg, stacklevel=2)
+        return result
+
+
+def _issue_warning(
+    msg: str,
+    category: type[Warning] | None = None,
+    stacklevel: int = 1,
+    *args,
+    **kwargs,
+) -> None:
+    if category is None:
+        log_msg = msg
+    else:
+        log_msg = f'{category.__name__}: {msg}'
+    diagnostics.log.warning(log_msg)
+    warn(msg, category, stacklevel + 1, *args, **kwargs)

--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -21,7 +21,7 @@ _ImportTargetField = Literal['name', 'index', 'alias', 'resolved_name']
 
 
 @dataclasses.dataclass(eq=True, frozen=True)
-class _ImportTarget:
+class ImportTarget:
     """
     An import target.
 
@@ -43,11 +43,16 @@ class _ImportTarget:
             Optional (1-indexed) line number on which the import occurs.
 
     Other attrs:
-        resolved_name (str):
+        resolved_name (str | None):
             Name under which the import can be found, e.g.:
 
             - ``import foo as bar`` -> ``'bar'``
             - ``import foo`` -> ``'foo'``
+            - ``from foo import *`` -> ``None``
+
+    Note:
+        Other than the above attributes, the remaining attributes and
+        methods of this object should be considered private.
     """
     name: str
     index: int
@@ -72,7 +77,7 @@ class _ImportTarget:
             )
 
     @classmethod
-    def from_ast_nodes(cls, nodes: Sequence[ast.AST]) -> list[Self]:
+    def _from_ast_nodes(cls, nodes: Sequence[ast.AST]) -> list[Self]:
         """
         Get all imports in the body of an AST node.
 
@@ -138,17 +143,12 @@ class _ImportTarget:
         ]
 
     @property
-    def resolved_name(self) -> str:
-        return self.alias or self.name
-
-    @property
-    def _star_import_source(self) -> str | None:
+    def resolved_name(self) -> str | None:
         # Note: star-imports are parsed into
-        # `_ImportTarget('module.name.*', index, '*', lineno)`
-        if self.alias != '*':
+        # `ImportTarget('module.name.*', index, '*', lineno)`
+        if self.alias == '*':
             return None
-        assert self.name.endswith('.*')
-        return self.name[:-2]
+        return self.alias or self.name
 
 
 class ProfmodExtractor:
@@ -278,25 +278,32 @@ class ProfmodExtractor:
         return modnames_to_profile
 
     @staticmethod
-    def _ast_get_imports_from_tree(tree: ast.Module) -> list[_ImportTarget]:
-        """Get all imports in an abstract syntax tree.
+    def _ast_get_imports_from_tree(
+        tree: ast.Module,
+    ) -> dict[tuple[str | int, ...], list[ImportTarget]]:
+        """Get all top-level imports in an abstract syntax tree.
 
         Args:
             tree (_ast.Module):
                 abstract syntax tree to fetch imports from.
 
         Returns:
-            import_targets (list[dict[str, str | int]])
+            import_targets (dict[tuple[str | int, ...], list[ImportTarget]])
+
+        Note:
+            Imports nested in e.g. try-except or if statements are not
+            currently returned.
 
         See also:
-            :py:meth:`._ImportTarget.from_ast_nodes`
+            :py:meth:`.ImportTarget._from_ast_nodes`
         """
-        return _ImportTarget.from_ast_nodes(tree.body)
+        # TODO: descend into bodied statements (e.g. try-except)
+        return {('body',): ImportTarget._from_ast_nodes(tree.body)}
 
     @staticmethod
     def _find_modnames_in_tree_imports(
-        modnames_to_profile: list[str], import_targets: list[_ImportTarget],
-    ) -> dict[int, list[_ImportTarget]]:
+        modnames_to_profile: list[str], import_targets: list[ImportTarget],
+    ) -> dict[int, list[ImportTarget]]:
         """Map modnames to imports from an abstract sytax tree.
 
         Find imports in import_targets, created from an abstract syntax tree, that match
@@ -311,20 +318,18 @@ class ProfmodExtractor:
             modnames_to_profile (list[str]):
                 list of dotted paths to profile.
 
-            import_targets (list[_ImportTarget]):
-                list of dicts of all imports in the tree
-                (see return value of
-                :py:meth:`._ast_get_imports_from_tree()`)
+            import_targets (list[ImportTarget]):
+                list of all import targets in the tree
 
         Returns:
-            filtered_imports (dict[int, list[_ImportTarget]]):
+            filtered_imports (dict[int, list[ImportTarget]]):
                 dict of imports found
                     key (int):
                         index of the (from-)import statement in AST
-                    value (list[_ImportTarget]):
+                    value (list[ImportTarget]):
                         list of filtered import targets
         """
-        filtered_imports: dict[int, list[_ImportTarget]] = {}
+        filtered_imports: dict[int, list[ImportTarget]] = {}
         modname_added_list = []
         for i, import_target in enumerate(import_targets):
             modname = import_target.name
@@ -344,21 +349,63 @@ class ProfmodExtractor:
                 filtered_imports[import_target.index] = [import_target]
         return filtered_imports
 
-    def _extract_all(self) -> dict[int, list[_ImportTarget]]:
+    def extract_all(self) -> dict[tuple[str | int, ...], list[ImportTarget]]:
         """
-        Find all the import targets to profile.
+        Map ``prof_mod`` to imports in an abstract syntax tree.
+        Takes the paths and dotted paths in ``prof_mod`` and finds their
+        respective imports in an abstract syntax tree, returning their
+        aliases and the location they appear in the AST.
+
+        Returns:
+            tree_imports_to_profile_dict \
+(dict[tuple[str | int, ...], list[ImportTarget]]);
+                dict of imports to profile
+                    key (tuple[str | int, ...]):
+                        Location of the import statement in the AST;
+                        e.g. ``('body', 0)`` for the case where it is
+                        the first statement in the
+                        :py:attr:`ast.Module.body`
+                    value (list[ImportTarget]):
+                        list of import targets, each with these
+                        attributes:
+
+                        name (str):
+                            Canonical name of the import
+                        index (int):
+                            Index where it occurs in e.g. a module body
+                        alias (str | None):
+                            Optional alias under which the import is
+                            inserted into the namespace
+                        lineno (int | None):
+                            Optional (1-indexed) line number associated
+                            with the target
+                        resolved_name (str | None):
+                            Name under which the import is inserted into
+                            the namespace (should never be
+                            :py:const`None` for non-star-imports)
+
+        Notes:
+            - As of now, ``from <module> import *`` is not supported,
+              and will result in a :py:class:`UserWarning`.
+
+            - Nested imports (e.g. imports in try-except/if blocks) are
+              not currently retrieved.
         """
         modnames_to_profile = self._get_modnames_to_profile_from_prof_mod(
             self._script_file, self._prof_mod
         )
         import_targets = self._ast_get_imports_from_tree(self._tree)
-        raw = self._find_modnames_in_tree_imports(
-            modnames_to_profile, import_targets,
-        )
-        filtered: dict[int, list[_ImportTarget]] = {}
-        star_imports: dict[int | None, set[_ImportTarget]] = {}
-        imports: Iterable[_ImportTarget]
-        for index, imports in raw.items():
+        raw: dict[tuple[str | int, ...], list[ImportTarget]] = {
+            (*loc, index): filtered_imports
+            for loc, imports in import_targets.items()
+            for index, filtered_imports in self._find_modnames_in_tree_imports(
+                modnames_to_profile, imports
+            ).items()
+        }
+        filtered: dict[tuple[str | int, ...], list[ImportTarget]] = {}
+        star_imports: dict[int | None, set[ImportTarget]] = {}
+        imports: Iterable[ImportTarget]
+        for loc, imports in raw.items():
             # TODO: runtime introspection of imports to handle
             # star-imports
             # Notes:
@@ -374,7 +421,7 @@ class ProfmodExtractor:
             #   but it doesn't hurt to be cautious
             indices_to_drop = [
                 i for i, imp in enumerate(imports)
-                if imp._star_import_source is not None
+                if imp.resolved_name is None  # Star-imports
             ]
             for i in reversed(indices_to_drop):
                 imp = imports.pop(i)
@@ -383,7 +430,7 @@ class ProfmodExtractor:
                 except KeyError:
                     star_imports[imp.lineno] = {imp}
             if imports:
-                filtered[index] = imports
+                filtered[loc] = imports
         if star_imports:
             msg_chunks: list[str] = [
                 (
@@ -403,39 +450,15 @@ class ProfmodExtractor:
             _issue_warning(sep.join(msg_chunks), stacklevel=3)
         return filtered
 
-    def extract_all(self) -> dict[int, list[str]]:
-        """Map prof_mod to imports in an abstract syntax tree.
-
-        Takes the paths and dotted paths in prof_mod and finds their respective imports in an
-        abstract syntax tree, returning their aliases and the index they appear in the AST.
-
-        Returns:
-            tree_imports_to_profile_dict (dict[int, list[str]]);
-                dict of imports to profile
-                    key (int):
-                        index of import in AST
-                    value (str | list[str]):
-                        list of aliases (or names if no alias used) to
-                        import
-
-        Notes:
-            As of now, ``from <module> import *`` is not supported, and
-            will result in a :py:class:`UserWarning`.
-        """
-        return {
-            index: [imp.resolved_name for imp in imports]
-            for index, imports in self._extract_all().items()
-        }
-
     def run(self) -> dict[int, str]:
         """
         Deprecated, legacy method kept for backward compatibility.
 
         Returns:
             tree_imports_to_profile_dict (dict[int, str])
-                dict of imports to profile
+                dict of top-level imports to profile
                     key (int):
-                        index of import in AST
+                        index of import in module AST's body
                     value (str):
                         alias (or name if no alias used) of the LAST
                         target to import in the corresponding
@@ -453,8 +476,11 @@ class ProfmodExtractor:
               the last target. If this results in import targets being
               dropped, a :py:class:`UserWarning` is issued.
 
-            - As of now, ``from <module> import *`` is not supported,
-              and will result in a :py:class:`UserWarning`.
+            - ``from <module> import *`` is not supported, and will
+              result in a :py:class:`UserWarning`.
+
+            - Nested imports (e.g. imports in try-except/if blocks) are
+              not retrieved.
         """
         msg = (
             '`ProfmodExtractor.run()` is now deprecated, because it cannot '
@@ -463,15 +489,26 @@ class ProfmodExtractor:
         )
         _issue_warning(msg, DeprecationWarning, stacklevel=2)
         result: dict[int, str] = {}
-        dropped: set[_ImportTarget] = set()
-        imports: Iterable[_ImportTarget]
-        for index, imports in self._extract_all().items():
+        dropped: set[ImportTarget] = set()
+        imports: Iterable[ImportTarget]
+        for index, imports in self.extract_all().items():
+            if not (
+                len(index) == 2
+                and index[0] == 'body'
+                and isinstance(index[1], int)
+            ):  # We only handle the top-level imports here
+                continue
             *remainder, last = imports
             dropped.update(remainder)
             dropped.discard(last)
-            result[index] = last.resolved_name
+            name = last.resolved_name
+            if name is None:
+                # Shouldn't happen with the current `.extract_all()`,
+                # but once we fix star-imports...
+                continue
+            result[index[1]] = name
         if dropped:
-            dropped_grouped: dict[int | None, set[_ImportTarget]] = {}
+            dropped_grouped: dict[int | None, set[ImportTarget]] = {}
             for imp in dropped:
                 try:
                     dropped_grouped[imp.lineno].add(imp)

--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -1,16 +1,154 @@
 from __future__ import annotations
 
 import ast
+import dataclasses
 import os
 import sys
-from typing import Literal, cast
+from collections.abc import Iterable, Sequence
+from typing import Any, Literal, cast
+from typing_extensions import Self
 from warnings import warn
+
 from .util_static import (
     modname_to_modpath,
     modpath_to_modname,
     package_modpaths,
 )
 from .. import _diagnostics as diagnostics
+
+
+_ImportTargetField = Literal['name', 'index', 'alias', 'resolved_name']
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class _ImportTarget:
+    """
+    An import target.
+
+    Init attrs:
+        name (str):
+            The real name of the import. e.g. ``import foo as bar``
+            -> ``'foo'``
+
+        index (int):
+            The index of the import as found in the AST body
+
+        alias (str | None):
+            The alias of an import if applicable. e.g.:
+
+            - ``import foo as bar`` -> ``'bar'``
+            - ``import foo`` -> ``None``
+
+        lineno (int | None):
+            Optional (1-indexed) line number on which the import occurs.
+
+    Other attrs:
+        resolved_name (str):
+            Name under which the import can be found, e.g.:
+
+            - ``import foo as bar`` -> ``'bar'``
+            - ``import foo`` -> ``'foo'``
+    """
+    name: str
+    index: int
+    alias: str | None = None
+    lineno: int | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Type verifications.
+        """
+        if not isinstance(self.name, str):
+            raise TypeError(f'.name = {self.name!r}: expected a str')
+        if not isinstance(self.index, int):
+            raise TypeError(
+                f'.index = {self.index!r}: expected an int',
+            )
+        if not (self.alias is None or isinstance(self.alias, str)):
+            raise TypeError(f'.alias = {self.alias!r}: expected a str or None')
+        if not (self.lineno is None or isinstance(self.lineno, int)):
+            raise TypeError(
+                f'.lineno = {self.lineno!r}: expected an int or None',
+            )
+
+    @classmethod
+    def from_ast_nodes(cls, nodes: Sequence[ast.AST]) -> list[Self]:
+        """
+        Get all imports in the body of an AST node.
+
+        Args:
+            nodes (Sequence[ast.AST]):
+                AST nodes to scan for imports;
+                examples: :py:attr:`ast.Module.body`,
+                :py:attr:`ast.If.orelse`.
+
+        Returns:
+            import_targets (list[Self]):
+                List of all imports amond the nodes.
+
+        Notes:
+            Imports nested inside the ``nodes`` are not as yet
+            handled, e.g. in
+
+            >>> # doctest: +SKIP
+            >>> from spam import ham
+            >>> try:
+            ...     from some_foo import bar
+            ... except ImportError:
+            ...     from other_foo import ersatz_bar as bar
+
+            Only ``ham`` is extracted but not ``bar``.
+        """
+        targets: list[Self] = []
+        modnames: set[str] = set()
+        for index, node in enumerate(nodes):
+            if isinstance(node, ast.Import):
+                new_targets: list[Self] = cls._from_import_node(index, node)
+            elif isinstance(node, ast.ImportFrom):
+                new_targets = cls._from_import_from_node(index, node)
+            else:  # TODO: descend into other bodied nodes
+                new_targets = []
+            for target in new_targets:
+                if target.name not in modnames:
+                    targets.append(target)
+                    modnames.add(target.name)
+        return targets
+
+    @classmethod
+    def _from_import_node(cls, index: int, node: ast.Import) -> list[Self]:
+        return [
+            cls(name.name, index, name.asname, name.lineno)
+            for name in node.names
+        ]
+
+    @classmethod
+    def _from_import_from_node(
+        cls, index: int, node: ast.ImportFrom,
+    ) -> list[Self]:
+        if node.module is None:  # `from . import ...`
+            return []
+        return [
+            cls(
+                f'{node.module}.{name.name}',
+                index,
+                name.asname or name.name,
+                name.lineno,
+            )
+            for name in node.names
+        ]
+
+    @property
+    def resolved_name(self) -> str:
+        return self.alias or self.name
+
+    @property
+    def _star_import_source(self) -> str | None:
+        # Note: star-imports are parsed into
+        # `_ImportTarget('module.name.*', index, '*', lineno)`
+        if self.alias != '*':
+            return None
+        assert self.name.endswith('.*')
+        return self.name[:-2]
 
 
 class ProfmodExtractor:
@@ -140,9 +278,7 @@ class ProfmodExtractor:
         return modnames_to_profile
 
     @staticmethod
-    def _ast_get_imports_from_tree(
-        tree: ast.Module,
-    ) -> list[dict[str, str | int | None]]:
+    def _ast_get_imports_from_tree(tree: ast.Module) -> list[_ImportTarget]:
         """Get all imports in an abstract syntax tree.
 
         Args:
@@ -150,55 +286,20 @@ class ProfmodExtractor:
                 abstract syntax tree to fetch imports from.
 
         Returns:
-            module_dict_list (list[Dict[str, str | int]]):
-                list of dicts of all imports in the tree, containing:
-                    name (str):
-                        the real name of the import. e.g. foo from "import foo as bar"
-                    alias (str):
-                        the alias of an import if applicable. e.g. bar from "import foo as bar"
-                    tree_index (int):
-                        the index of the import as found in the tree
+            import_targets (list[dict[str, str | int]])
+
+        See also:
+            :py:meth:`._ImportTarget.from_ast_nodes`
         """
-        module_dict_list: list[dict[str, str | int | None]] = []
-        module_dict: dict[str, str | int | None]
-        modname_list = []
-        for idx, node in enumerate(tree.body):
-            if isinstance(node, ast.Import):
-                for name in node.names:
-                    modname = name.name
-                    if modname not in modname_list:
-                        alias = name.asname
-                        module_dict = {
-                            'name': modname,
-                            'alias': alias,
-                            'tree_index': idx,
-                        }
-                        module_dict_list.append(module_dict)
-                        modname_list.append(modname)
-            elif isinstance(node, ast.ImportFrom):
-                if node.module is None:
-                    continue
-                for name in node.names:
-                    modname = f'{node.module}.{name.name}'
-                    if modname not in modname_list:
-                        alias = name.asname or name.name
-                        module_dict = {
-                            'name': modname,
-                            'alias': alias,
-                            'tree_index': idx,
-                        }
-                        module_dict_list.append(module_dict)
-                        modname_list.append(modname)
-        return module_dict_list
+        return _ImportTarget.from_ast_nodes(tree.body)
 
     @staticmethod
     def _find_modnames_in_tree_imports(
-        modnames_to_profile: list[str],
-        module_dict_list: list[dict[str, str | int | None]],
-    ) -> dict[int, list[str]]:
+        modnames_to_profile: list[str], import_targets: list[_ImportTarget],
+    ) -> dict[int, list[_ImportTarget]]:
         """Map modnames to imports from an abstract sytax tree.
 
-        Find imports in modue_dict_list, created from an abstract syntax tree, that match
+        Find imports in import_targets, created from an abstract syntax tree, that match
         dotted paths in modnames_to_profile.
         When a submodule is imported, both the submodule and the parent module are checked
         whether they are in modnames_to_profile. As the user can ask to profile
@@ -210,41 +311,97 @@ class ProfmodExtractor:
             modnames_to_profile (list[str]):
                 list of dotted paths to profile.
 
-            module_dict_list (list[Dict[str, str | int]]):
-                list of dicts of all imports in the tree.
+            import_targets (list[_ImportTarget]):
+                list of dicts of all imports in the tree
+                (see return value of
+                :py:meth:`._ast_get_imports_from_tree()`)
 
         Returns:
-            modnames_found_in_tree (dict[int, list[str]]):
+            filtered_imports (dict[int, list[_ImportTarget]]):
                 dict of imports found
                     key (int):
                         index of the (from-)import statement in AST
-                    value (list[str]):
-                        list of aliases (or names if no alias used) to
-                        import
+                    value (list[_ImportTarget]):
+                        list of filtered import targets
         """
-        modnames_found_in_tree: dict[int, list[str]] = {}
+        filtered_imports: dict[int, list[_ImportTarget]] = {}
         modname_added_list = []
-        for i, module_dict in enumerate(module_dict_list):
-            modname = module_dict['name']
-            if not isinstance(modname, str):
-                continue
+        for i, import_target in enumerate(import_targets):
+            modname = import_target.name
             if modname in modname_added_list:
                 continue
-            """check if either the parent module or submodule are in modnames_to_profile"""
+            # Check if either the parent module or submodule are in
+            # `modnames_to_profile`
             if (
                 modname not in modnames_to_profile
                 and modname.rsplit('.', 1)[0] not in modnames_to_profile
             ):
                 continue
-            name = module_dict['alias'] or modname
-            if not isinstance(name, str):
-                raise TypeError('should have gotten a str')
             modname_added_list.append(modname)
-            tree_index = module_dict['tree_index']
-            if not isinstance(tree_index, int):
-                raise TypeError('should have gotten an int')
-            modnames_found_in_tree.setdefault(tree_index, []).append(name)
-        return modnames_found_in_tree
+            try:
+                filtered_imports[import_target.index].append(import_target)
+            except KeyError:  # No imports recorded for the statement
+                filtered_imports[import_target.index] = [import_target]
+        return filtered_imports
+
+    def _extract_all(self) -> dict[int, list[_ImportTarget]]:
+        """
+        Find all the import targets to profile.
+        """
+        modnames_to_profile = self._get_modnames_to_profile_from_prof_mod(
+            self._script_file, self._prof_mod
+        )
+        import_targets = self._ast_get_imports_from_tree(self._tree)
+        raw = self._find_modnames_in_tree_imports(
+            modnames_to_profile, import_targets,
+        )
+        filtered: dict[int, list[_ImportTarget]] = {}
+        star_imports: dict[int | None, set[_ImportTarget]] = {}
+        imports: Iterable[_ImportTarget]
+        for index, imports in raw.items():
+            # TODO: runtime introspection of imports to handle
+            # star-imports
+            # Notes:
+            # - We don't issue the warning in
+            #   `._find_modnames_in_tree_imports()` because that is a
+            #   static method and doesn't have access to the file from
+            #   which the AST is generated, which we want to include in
+            #   the warning message.
+            # - As far normal Python syntax is concerned, each
+            #   import-from statement can have at most one `*` target,
+            #   which would be the sole target thereof (so
+            #   `indices_to_drop` should either be `[]` or `[0]`);
+            #   but it doesn't hurt to be cautious
+            indices_to_drop = [
+                i for i, imp in enumerate(imports)
+                if imp._star_import_source is not None
+            ]
+            for i in reversed(indices_to_drop):
+                imp = imports.pop(i)
+                try:
+                    star_imports[imp.lineno].add(imp)
+                except KeyError:
+                    star_imports[imp.lineno] = {imp}
+            if imports:
+                filtered[index] = imports
+        if star_imports:
+            msg_chunks: list[str] = [
+                (
+                    '{}: {} would-be profiling target(s) dropped because the '
+                    "we don't currently handle `from ... import *` statements:"
+                ).format(self._script_file, len(star_imports)),
+            ]
+            for lineno, imports in sorted(
+                star_imports.items(), key=_import_dict_item_sort_key,
+            ):
+                lineno_repr = '???' if lineno is None else str(lineno)
+                targets = ', '.join(sorted(imp.name for imp in imports))
+                msg_chunks.append(f'- line {lineno_repr}: {targets}')
+            sep = ' ' if len(msg_chunks) < 3 else '\n'
+            # Attribute the warning to the caller of `.run()` or
+            # `.extract_all()`
+            _issue_warning(sep.join(msg_chunks), stacklevel=3)
+        return filtered
 
     def extract_all(self) -> dict[int, list[str]]:
         """Map prof_mod to imports in an abstract syntax tree.
@@ -253,23 +410,22 @@ class ProfmodExtractor:
         abstract syntax tree, returning their aliases and the index they appear in the AST.
 
         Returns:
-            tree_imports_to_profile_dict (dict[int, str] | dict[int, list[str]]);
+            tree_imports_to_profile_dict (dict[int, list[str]]);
                 dict of imports to profile
                     key (int):
                         index of import in AST
                     value (str | list[str]):
                         list of aliases (or names if no alias used) to
                         import
+
+        Notes:
+            As of now, ``from <module> import *`` is not supported, and
+            will result in a :py:class:`UserWarning`.
         """
-        modnames_to_profile = self._get_modnames_to_profile_from_prof_mod(
-            self._script_file, self._prof_mod
-        )
-
-        module_dict_list = self._ast_get_imports_from_tree(self._tree)
-
-        return self._find_modnames_in_tree_imports(
-            modnames_to_profile, module_dict_list,
-        )
+        return {
+            index: [imp.resolved_name for imp in imports]
+            for index, imports in self._extract_all().items()
+        }
 
     def run(self) -> dict[int, str]:
         """
@@ -296,6 +452,9 @@ class ProfmodExtractor:
             - For multi-target import statements, this only preserves
               the last target. If this results in import targets being
               dropped, a :py:class:`UserWarning` is issued.
+
+            - As of now, ``from <module> import *`` is not supported,
+              and will result in a :py:class:`UserWarning`.
         """
         msg = (
             '`ProfmodExtractor.run()` is now deprecated, because it cannot '
@@ -304,24 +463,47 @@ class ProfmodExtractor:
         )
         _issue_warning(msg, DeprecationWarning, stacklevel=2)
         result: dict[int, str] = {}
-        dropped_names: set[str] = set()
-        for i, names in self.extract_all().items():
-            *remainder, last = names
-            dropped_names.update(remainder)
-            # In case a later import shadows a dropped name from an
-            # earlier import
-            dropped_names.discard(last)
-            result[i] = last
-        dropped_names -= set(result.values())
-        if dropped_names:
-            msg = (
-                '{}: {} would-be profiling target(s) dropped because the '
-                'import statement(s) are multi-target: {!r}'
-            ).format(
-                self._script_file, len(dropped_names), sorted(dropped_names),
-            )
-            _issue_warning(msg, stacklevel=2)
+        dropped: set[_ImportTarget] = set()
+        imports: Iterable[_ImportTarget]
+        for index, imports in self._extract_all().items():
+            *remainder, last = imports
+            dropped.update(remainder)
+            dropped.discard(last)
+            result[index] = last.resolved_name
+        if dropped:
+            dropped_grouped: dict[int | None, set[_ImportTarget]] = {}
+            for imp in dropped:
+                try:
+                    dropped_grouped[imp.lineno].add(imp)
+                except KeyError:
+                    dropped_grouped[imp.lineno] = {imp}
+            msg_chunks: list[str] = [
+                (
+                    '{}: {} would-be profiling target(s) dropped because the '
+                    'import statement(s) are multi-target:'
+                ).format(self._script_file, len(dropped)),
+            ]
+            for lineno, imports in sorted(
+                dropped_grouped.items(), key=_import_dict_item_sort_key,
+            ):
+                lineno_repr = '???' if lineno is None else str(lineno)
+                targets = ', '.join(sorted(
+                    imp.name
+                    if imp.alias is None else
+                    f'{imp.alias} (= {imp.name})'
+                    for imp in imports
+                ))
+                msg_chunks.append(f'- line {lineno_repr}: {targets}')
+            sep = ' ' if len(msg_chunks) < 3 else '\n'
+            _issue_warning(sep.join(msg_chunks), stacklevel=2)
         return result
+
+
+def _import_dict_item_sort_key(item: tuple[int | None, Any]) -> float:
+    lineno, _ = item
+    if lineno is None:
+        return float('inf')
+    return lineno
 
 
 def _issue_warning(

--- a/line_profiler/autoprofile/profmod_extractor.py
+++ b/line_profiler/autoprofile/profmod_extractor.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import ast
-import dataclasses
 import os
 import sys
-from collections.abc import Iterable, Sequence
-from typing import Any, Literal, cast
-from typing_extensions import Self
+from typing import cast
 from warnings import warn
 
 from .util_static import (
@@ -15,140 +12,7 @@ from .util_static import (
     package_modpaths,
 )
 from .. import _diagnostics as diagnostics
-
-
-_ImportTargetField = Literal['name', 'index', 'alias', 'resolved_name']
-
-
-@dataclasses.dataclass(eq=True, frozen=True)
-class ImportTarget:
-    """
-    An import target.
-
-    Init attrs:
-        name (str):
-            The real name of the import. e.g. ``import foo as bar``
-            -> ``'foo'``
-
-        index (int):
-            The index of the import as found in the AST body
-
-        alias (str | None):
-            The alias of an import if applicable. e.g.:
-
-            - ``import foo as bar`` -> ``'bar'``
-            - ``import foo`` -> ``None``
-
-        lineno (int | None):
-            Optional (1-indexed) line number on which the import occurs.
-
-    Other attrs:
-        resolved_name (str | None):
-            Name under which the import can be found, e.g.:
-
-            - ``import foo as bar`` -> ``'bar'``
-            - ``import foo`` -> ``'foo'``
-            - ``from foo import *`` -> ``None``
-
-    Note:
-        Other than the above attributes, the remaining attributes and
-        methods of this object should be considered private.
-    """
-    name: str
-    index: int
-    alias: str | None = None
-    lineno: int | None = None
-
-    def __post_init__(self) -> None:
-        """
-        Type verifications.
-        """
-        if not isinstance(self.name, str):
-            raise TypeError(f'.name = {self.name!r}: expected a str')
-        if not isinstance(self.index, int):
-            raise TypeError(
-                f'.index = {self.index!r}: expected an int',
-            )
-        if not (self.alias is None or isinstance(self.alias, str)):
-            raise TypeError(f'.alias = {self.alias!r}: expected a str or None')
-        if not (self.lineno is None or isinstance(self.lineno, int)):
-            raise TypeError(
-                f'.lineno = {self.lineno!r}: expected an int or None',
-            )
-
-    @classmethod
-    def _from_ast_nodes(cls, nodes: Sequence[ast.AST]) -> list[Self]:
-        """
-        Get all imports in the body of an AST node.
-
-        Args:
-            nodes (Sequence[ast.AST]):
-                AST nodes to scan for imports;
-                examples: :py:attr:`ast.Module.body`,
-                :py:attr:`ast.If.orelse`.
-
-        Returns:
-            import_targets (list[Self]):
-                List of all imports amond the nodes.
-
-        Notes:
-            Imports nested inside the ``nodes`` are not as yet
-            handled, e.g. in
-
-            >>> # doctest: +SKIP
-            >>> from spam import ham
-            >>> try:
-            ...     from some_foo import bar
-            ... except ImportError:
-            ...     from other_foo import ersatz_bar as bar
-
-            Only ``ham`` is extracted but not ``bar``.
-        """
-        targets: list[Self] = []
-        modnames: set[str] = set()
-        for index, node in enumerate(nodes):
-            if isinstance(node, ast.Import):
-                new_targets: list[Self] = cls._from_import_node(index, node)
-            elif isinstance(node, ast.ImportFrom):
-                new_targets = cls._from_import_from_node(index, node)
-            else:  # TODO: descend into other bodied nodes
-                new_targets = []
-            for target in new_targets:
-                if target.name not in modnames:
-                    targets.append(target)
-                    modnames.add(target.name)
-        return targets
-
-    @classmethod
-    def _from_import_node(cls, index: int, node: ast.Import) -> list[Self]:
-        return [
-            cls(name.name, index, name.asname, name.lineno)
-            for name in node.names
-        ]
-
-    @classmethod
-    def _from_import_from_node(
-        cls, index: int, node: ast.ImportFrom,
-    ) -> list[Self]:
-        if node.module is None:  # `from . import ...`
-            return []
-        return [
-            cls(
-                f'{node.module}.{name.name}',
-                index,
-                name.asname or name.name,
-                name.lineno,
-            )
-            for name in node.names
-        ]
-
-    @property
-    def resolved_name(self) -> str | None:
-        # Note: star-imports are parsed into
-        # `ImportTarget('module.name.*', index, '*', lineno)`
-        if self.alias == '*':
-            return None
-        return self.alias or self.name
+from ._import_targets import ImportTarget
 
 
 class ProfmodExtractor:
@@ -403,8 +267,7 @@ class ProfmodExtractor:
             ).items()
         }
         filtered: dict[tuple[str | int, ...], list[ImportTarget]] = {}
-        star_imports: dict[int | None, set[ImportTarget]] = {}
-        imports: Iterable[ImportTarget]
+        star_imports: set[ImportTarget] = set()
         for loc, imports in raw.items():
             # TODO: runtime introspection of imports to handle
             # star-imports
@@ -425,29 +288,15 @@ class ProfmodExtractor:
             ]
             for i in reversed(indices_to_drop):
                 imp = imports.pop(i)
-                try:
-                    star_imports[imp.lineno].add(imp)
-                except KeyError:
-                    star_imports[imp.lineno] = {imp}
+                star_imports.add(imp)
             if imports:
                 filtered[loc] = imports
-        if star_imports:
-            msg_chunks: list[str] = [
-                (
-                    '{}: {} would-be profiling target(s) dropped because the '
-                    "we don't currently handle `from ... import *` statements:"
-                ).format(self._script_file, len(star_imports)),
-            ]
-            for lineno, imports in sorted(
-                star_imports.items(), key=_import_dict_item_sort_key,
-            ):
-                lineno_repr = '???' if lineno is None else str(lineno)
-                targets = ', '.join(sorted(imp.name for imp in imports))
-                msg_chunks.append(f'- line {lineno_repr}: {targets}')
-            sep = ' ' if len(msg_chunks) < 3 else '\n'
-            # Attribute the warning to the caller of `.run()` or
-            # `.extract_all()`
-            _issue_warning(sep.join(msg_chunks), stacklevel=3)
+        ImportTarget._check_and_warn_dropped_imports(
+            star_imports,
+            "we don't currently handle `from ... import *` statements",
+            self._script_file,
+            stacklevel=2,  # Attribute warning to caller
+        )
         return filtered
 
     def run(self) -> dict[int, str]:
@@ -487,10 +336,10 @@ class ProfmodExtractor:
             'correctly resolve multi-target import statements; '
             'use `ProfmodExtractor.extract_all()` instead.'
         )
-        _issue_warning(msg, DeprecationWarning, stacklevel=2)
+        diagnostics.log.warning(f'DeprecationWarning: {msg}')
+        warn(msg, DeprecationWarning, stacklevel=2)  # Caller
         result: dict[int, str] = {}
         dropped: set[ImportTarget] = set()
-        imports: Iterable[ImportTarget]
         for index, imports in self.extract_all().items():
             if not (
                 len(index) == 2
@@ -507,52 +356,10 @@ class ProfmodExtractor:
                 # but once we fix star-imports...
                 continue
             result[index[1]] = name
-        if dropped:
-            dropped_grouped: dict[int | None, set[ImportTarget]] = {}
-            for imp in dropped:
-                try:
-                    dropped_grouped[imp.lineno].add(imp)
-                except KeyError:
-                    dropped_grouped[imp.lineno] = {imp}
-            msg_chunks: list[str] = [
-                (
-                    '{}: {} would-be profiling target(s) dropped because the '
-                    'import statement(s) are multi-target:'
-                ).format(self._script_file, len(dropped)),
-            ]
-            for lineno, imports in sorted(
-                dropped_grouped.items(), key=_import_dict_item_sort_key,
-            ):
-                lineno_repr = '???' if lineno is None else str(lineno)
-                targets = ', '.join(sorted(
-                    imp.name
-                    if imp.alias is None else
-                    f'{imp.alias} (= {imp.name})'
-                    for imp in imports
-                ))
-                msg_chunks.append(f'- line {lineno_repr}: {targets}')
-            sep = ' ' if len(msg_chunks) < 3 else '\n'
-            _issue_warning(sep.join(msg_chunks), stacklevel=2)
+        ImportTarget._check_and_warn_dropped_imports(
+            dropped,
+            'the import statement(s) is/are multi-target',
+            self._script_file,
+            stacklevel=2,  # Attribute warning to caller
+        )
         return result
-
-
-def _import_dict_item_sort_key(item: tuple[int | None, Any]) -> float:
-    lineno, _ = item
-    if lineno is None:
-        return float('inf')
-    return lineno
-
-
-def _issue_warning(
-    msg: str,
-    category: type[Warning] | None = None,
-    stacklevel: int = 1,
-    *args,
-    **kwargs,
-) -> None:
-    if category is None:
-        log_msg = msg
-    else:
-        log_msg = f'{category.__name__}: {msg}'
-    diagnostics.log.warning(log_msg)
-    warn(msg, category, stacklevel + 1, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,6 @@ docstring-code-format = false
 unused-ignore-comment = "ignore"
 unused-type-ignore-comment = "ignore"
 unresolved-import = "ignore"
+
+[tool.ty.terminal]
+error-on-warning = false  # No longer the default since 0.0.52

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
+
+import ast
+import contextlib
 import os
 import re
 import subprocess
 import sys
 import shlex
 import tempfile
-from ast import unparse
+from collections.abc import Callable, Sequence
+from functools import partial
+from typing import Literal, cast
+from warnings import catch_warnings, WarningMessage
 
 import pytest
 import ubelt as ub
 from line_profiler.autoprofile.ast_tree_profiler import AstTreeProfiler
+from line_profiler.autoprofile.profmod_extractor import ProfmodExtractor
 
 
 def test_single_function_autoprofile():
@@ -1219,8 +1226,8 @@ def test_multitarget_import_resolution(
 ) -> None:
     """
     Test that (from-)import statements with multiple targets are
-    correctly transformed, resolving to the correct entities being
-    profiled.
+    correctly transformed by :py:class:`.AstTreeProfiler`, resolving to
+    the correct entities being profiled.
 
     See also:
         Issue #433
@@ -1236,13 +1243,13 @@ def test_multitarget_import_resolution(
 
         if __name__ == '__main__':
             pass
-        """
+        """,
     )
     with tempfile.TemporaryDirectory() as tmp:
         fpath = ub.Path(tmp) / 'script.py'
         fpath.write_text(input_module)
         module_ast = AstTreeProfiler(str(fpath), prof_mod, False).profile()
-    output_module = unparse(module_ast)
+    output_module = ast.unparse(module_ast)
 
     for target, profiled in {
         'os': prof_os,
@@ -1252,4 +1259,133 @@ def test_multitarget_import_resolution(
     }.items():
         pattern = rf'add_imported_function_or_module\({target}\)'
         assert bool(re.search(pattern, output_module)) == profiled
-        
+
+
+@pytest.mark.parametrize(
+    ('prof_mod', 'expected',
+     'assume_single_target_imports', 'expect_dropped_target_warning'),
+    [(['foo', 'foobar.ham'], {0: ['foo'], 2: ['ham']}, False, None),
+     # This doesn't result in a `UserWarning` for dropped targets,
+     # because there is only one selected target on the multi-target
+     # import line
+     (['foo', 'foobar.ham'], {0: 'foo', 2: 'ham'}, True, None),
+     # Also test not passing `assume_single_target_imports` (defaults to
+     # true)
+     (['foo', 'foobar.ham'], {0: 'foo', 2: 'ham'}, True, None),
+     (['baz', 'foobar'], {1: ['baz'], 2: ['spam', 'ham', 'jam']}, False, None),
+     # This however results in the warning that `spam` and `ham` are
+     # supposed to be profiled, but are dropped
+     (['baz', 'foobar'], {1: 'baz', 2: 'jam'}, True,
+      r"2 .* target.* dropped .* \['ham', 'spam'\]")])
+def test_profmod_extractor_multitarget_behavior(
+    prof_mod: list[str],
+    expected: dict[str, int] | dict[str, list[int]],
+    assume_single_target_imports: bool | None,
+    expect_dropped_target_warning: str | None,
+) -> None:
+    """
+    Test that :py:meth:`.ProfmodExtractor.run` behaves as expected:
+
+    ``assume_single_target_imports=True``
+
+        - Return ``dict[int, str]``, in accordance with legacy behavior
+
+        - Warn against bare calls not specifying otherwise
+
+        - Warn against dropped profiling targets (if any)
+
+    ``assume_single_target_imports=True``
+
+        - Return ``dict[int, list[str]]``
+
+        - Does not result in the above warnings
+    """
+    def forbid_warnings(
+        msgs: Sequence[WarningMessage],
+        pattern: str,
+        category: type[Warning] = Warning,
+    ) -> None:
+        regex = re.compile(pattern)
+        for msg in msgs:
+            if not issubclass(msg.category, category):
+                continue
+            if not regex.search(str(msg.message)):
+                continue
+            raise ValueError(
+                f'{pattern=!r}, {category=!r}: matched warning: {msg}',
+            )
+
+    def expect_warnings(
+        msgs: Sequence[WarningMessage],
+        pattern: str,
+        category: type[Warning] = Warning,
+    ) -> None:
+        regex = re.compile(pattern)
+        if any(
+            issubclass(msg.category, category)
+            and regex.search(str(msg.message))
+            for msg in msgs
+        ):
+            return
+        raise ValueError(
+            f'{pattern=!r}, {category=!r}: '
+            f'no matches among {len(msgs)} warnings: '
+            f'{[str(m) for m in msgs]!r}',
+        )
+
+    code = ub.codeblock(
+        """
+        import foo, bar
+        import baz
+        from foobar import spam, ham, eggs as jam
+
+
+        def func() -> None:
+            pass
+        """,
+    )
+    depr_warning_pattern = 'assume_single_target_imports'
+    targets_warning_pattern = 'profiling target.* dropped.* multi-target'
+    checks: list[Callable[[Sequence[WarningMessage]], None]] = []
+    with contextlib.ExitStack() as stack:
+        tmpdir = stack.enter_context(tempfile.TemporaryDirectory())
+        fname = ub.Path(tmpdir) / 'script.py'
+        fname.write_text(code)
+
+        warnings = stack.enter_context(catch_warnings(record=True))
+        if assume_single_target_imports in (True, None):
+            checks.append(partial(
+                expect_warnings,
+                pattern=depr_warning_pattern, category=DeprecationWarning,
+            ))
+        else:
+            checks.append(partial(
+                forbid_warnings,
+                pattern=depr_warning_pattern, category=DeprecationWarning,
+            ))
+        if expect_dropped_target_warning:
+            checks.append(partial(
+                expect_warnings,
+                pattern=expect_dropped_target_warning,
+                category=UserWarning,
+            ))
+        else:
+            checks.append(partial(
+                forbid_warnings,
+                pattern=targets_warning_pattern, category=UserWarning,
+            ))
+
+        extractor = ProfmodExtractor(ast.parse(code), str(fname), prof_mod)
+        if assume_single_target_imports is None:  # Default
+            result: dict[int, str] | dict[int, list[str]] = extractor.run()
+        else:
+            result = extractor.run(  # `mypy` needs a bit of help here
+                assume_single_target_imports=cast(
+                    Literal[True, False],
+                    assume_single_target_imports,
+                ),
+            )
+
+    assert result == expected
+    for check in checks:
+        check(warnings)

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -5,9 +5,11 @@ import subprocess
 import sys
 import shlex
 import tempfile
+from ast import unparse
 
 import pytest
 import ubelt as ub
+from line_profiler.autoprofile.ast_tree_profiler import AstTreeProfiler
 
 
 def test_single_function_autoprofile():
@@ -1197,3 +1199,57 @@ def test_autoprofile_callable_wrapper_objects(prof_mod, profiled_funcs):
             f'^Function: {prefix}{func}', raw_output, re.MULTILINE
         )
         assert bool(in_output) == (func in profiled_funcs)
+
+
+@pytest.mark.parametrize(
+    ('prof_mod', 'prof_os', 'prof_minidom', 'prof_pulldom',
+     'prof_elem', 'prof_etree', 'prof_parser'),
+    # Trivial cases
+    [([], False, False, False, False, False, False),
+     (['os', 'foo.bar'], True, False, False, False, False, False),
+     (['xml.etree.ElementTree'], False, False, False, True, True, True),
+     (['xml.etree.ElementTree.Element', 'xml.etree.ElementTree.XMLParser',
+       'xml.dom.minidom'],
+      False, True, False, True, False, True)])
+def test_multitarget_import_resolution(
+    prof_mod: list[str],
+    prof_os: bool,
+    prof_minidom: bool, prof_pulldom: bool,
+    prof_elem: bool, prof_etree: bool, prof_parser: bool,
+) -> None:
+    """
+    Test that (from-)import statements with multiple targets are
+    correctly transformed, resolving to the correct entities being
+    profiled.
+
+    See also:
+        Issue #433
+    """
+    input_module = ub.codeblock(
+        """
+        import os
+        from xml.dom import minidom, pulldom
+        from xml.etree.ElementTree import (
+            Element, ElementTree, XMLParser,
+        )
+
+
+        if __name__ == '__main__':
+            pass
+        """
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        fpath = ub.Path(tmp) / 'script.py'
+        fpath.write_text(input_module)
+        module_ast = AstTreeProfiler(str(fpath), prof_mod, False).profile()
+    output_module = unparse(module_ast)
+
+    for target, profiled in {
+        'os': prof_os,
+        'minidom': prof_minidom, 'pulldom': prof_pulldom,
+        'Element': prof_elem, 'ElementTree': prof_etree,
+        'XMLParser': prof_parser,
+    }.items():
+        pattern = rf'add_imported_function_or_module\({target}\)'
+        assert bool(re.search(pattern, output_module)) == profiled
+        

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -9,7 +9,7 @@ import sys
 import shlex
 import tempfile
 from collections.abc import Collection, Sequence
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 from warnings import catch_warnings, WarningMessage
 
 import pytest
@@ -1538,6 +1538,10 @@ def test_handle_star_imports(
         warnings = stack.enter_context(catch_warnings(record=True))
         rewriter = AstTreeProfiler(str(fpath), prof_mod, profile_imports)
         module_ast = rewriter.profile()
+
+    # Check that we no longer get a `SyntaxError` from
+    # `add_imported_function_or_module(*)`
+    compile(module_ast, str(fpath), 'exec')
 
     # Check the issuance of warnings related to star-imports
     _check_warnings(warnings, warning_checks)

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -8,9 +8,7 @@ import subprocess
 import sys
 import shlex
 import tempfile
-from collections.abc import Callable, Sequence
-from functools import partial
-from typing import Literal, cast
+from typing import Any, ClassVar, Literal
 from warnings import catch_warnings, WarningMessage
 
 import pytest
@@ -1262,130 +1260,172 @@ def test_multitarget_import_resolution(
 
 
 @pytest.mark.parametrize(
-    ('prof_mod', 'expected',
-     'assume_single_target_imports', 'expect_dropped_target_warning'),
-    [(['foo', 'foobar.ham'], {0: ['foo'], 2: ['ham']}, False, None),
+    ('prof_mod', 'expected', 'method', 'expect_dropped_target_warning'),
+    [(['foo', 'foobar.ham'], {0: ['foo'], 2: ['ham']}, 'extract_all', None),
+     (['baz', 'foobar'], {1: ['baz'], 2: ['spam', 'ham', 'jam']},
+      'extract_all', None),
+     (['foobar', 'qux'], {2: ['spam', 'ham', 'jam'], 3: ['ham']},
+      'extract_all', None),
      # This doesn't result in a `UserWarning` for dropped targets,
      # because there is only one selected target on the multi-target
      # import line
-     (['foo', 'foobar.ham'], {0: 'foo', 2: 'ham'}, True, None),
-     # Also test not passing `assume_single_target_imports` (defaults to
-     # true)
-     (['foo', 'foobar.ham'], {0: 'foo', 2: 'ham'}, True, None),
-     (['baz', 'foobar'], {1: ['baz'], 2: ['spam', 'ham', 'jam']}, False, None),
+     (['foo', 'foobar.ham'], {0: 'foo', 2: 'ham'}, 'run', None),
      # This however results in the warning that `spam` and `ham` are
      # supposed to be profiled, but are dropped
-     (['baz', 'foobar'], {1: 'baz', 2: 'jam'}, True,
-      r"2 .* target.* dropped .* \['ham', 'spam'\]")])
+     (['baz', 'foobar'], {1: 'baz', 2: 'jam'}, 'run',
+      r"2 .* target.* dropped .* \['ham', 'spam'\]"),
+     # And here we only warn against `spam`, because `foobar.ham` is
+     # shadowed by `qux.ham`
+     (['foobar', 'qux'], {2: 'jam', 3: 'ham'}, 'run',
+      r"1 .* target.* dropped .* \['spam'\]")])
 def test_profmod_extractor_multitarget_behavior(
     prof_mod: list[str],
-    expected: dict[str, int] | dict[str, list[int]],
-    assume_single_target_imports: bool | None,
+    expected: dict[int, str] | dict[int, list[str]],
+    method: Literal['extract_all', 'run'],
     expect_dropped_target_warning: str | None,
 ) -> None:
     """
-    Test that :py:meth:`.ProfmodExtractor.run` behaves as expected:
+    Test that :py:meth:`.ProfmodExtractor.extract_all` and
+    :py:meth:`.ProfmodExtractor.run` behaves as expected:
 
-    ``assume_single_target_imports=True``
+    ``.run()`` (legacy method):
 
-        - Return ``dict[int, str]``, in accordance with legacy behavior
+        - Returns ``dict[int, str]``, where ``str`` is the last target
+          in a (multi-target) import(-from) statement
 
-        - Warn against bare calls not specifying otherwise
+        - Issues a :py:class:`DeprecationWarning` urging users to use
+          :py:meth:`.ProfmodExtractor.extract_all` instead
 
-        - Warn against dropped profiling targets (if any)
+        - Issues a :py:class:`UserWarning` against dropped profiling
+          targets (if any)
 
-    ``assume_single_target_imports=True``
+    ``.extract_all()`` (new method):
 
-        - Return ``dict[int, list[str]]``
+        - Returns ``dict[int, list[str]]``
 
         - Does not result in the above warnings
+
+    See also:
+        Issue #433
     """
-    def forbid_warnings(
-        msgs: Sequence[WarningMessage],
-        pattern: str,
-        category: type[Warning] = Warning,
-    ) -> None:
-        regex = re.compile(pattern)
-        for msg in msgs:
-            if not issubclass(msg.category, category):
-                continue
-            if not regex.search(str(msg.message)):
-                continue
-            raise ValueError(
-                f'{pattern=!r}, {category=!r}: matched warning: {msg}',
-            )
-
-    def expect_warnings(
-        msgs: Sequence[WarningMessage],
-        pattern: str,
-        category: type[Warning] = Warning,
-    ) -> None:
-        regex = re.compile(pattern)
-        if any(
-            issubclass(msg.category, category)
-            and regex.search(str(msg.message))
-            for msg in msgs
-        ):
-            return
-        raise ValueError(
-            f'{pattern=!r}, {category=!r}: '
-            f'no matches among {len(msgs)} warnings: '
-            f'{[str(m) for m in msgs]!r}',
-        )
-
     code = ub.codeblock(
         """
         import foo, bar
         import baz
         from foobar import spam, ham, eggs as jam
+        from qux import ham  # This shadows `foobar.ham` above
 
 
         def func() -> None:
             pass
         """,
     )
-    depr_warning_pattern = 'assume_single_target_imports'
+    depr_warning_pattern = 'run.* deprecated.* use .*extract_all'
     targets_warning_pattern = 'profiling target.* dropped.* multi-target'
-    checks: list[Callable[[Sequence[WarningMessage]], None]] = []
+    warnings: list[WarningMessage]
+    checks: list[tuple[bool, str, type[Warning]]] = []
+    # Check that the deprecation warning is only issued when using
+    # `.run()`
+    checks.append((method == 'run', depr_warning_pattern, DeprecationWarning))
+    # Check that the user warnin is only issued when a target has been
+    # dropped (and not shadowed by a later import)
+    if expect_dropped_target_warning:
+        checks.append((True, expect_dropped_target_warning, UserWarning))
+    else:
+        checks.append((False, targets_warning_pattern, UserWarning))
+
     with contextlib.ExitStack() as stack:
         tmpdir = stack.enter_context(tempfile.TemporaryDirectory())
         fname = ub.Path(tmpdir) / 'script.py'
         fname.write_text(code)
 
         warnings = stack.enter_context(catch_warnings(record=True))
-        if assume_single_target_imports in (True, None):
-            checks.append(partial(
-                expect_warnings,
-                pattern=depr_warning_pattern, category=DeprecationWarning,
-            ))
-        else:
-            checks.append(partial(
-                forbid_warnings,
-                pattern=depr_warning_pattern, category=DeprecationWarning,
-            ))
-        if expect_dropped_target_warning:
-            checks.append(partial(
-                expect_warnings,
-                pattern=expect_dropped_target_warning,
-                category=UserWarning,
-            ))
-        else:
-            checks.append(partial(
-                forbid_warnings,
-                pattern=targets_warning_pattern, category=UserWarning,
-            ))
-
         extractor = ProfmodExtractor(ast.parse(code), str(fname), prof_mod)
-        if assume_single_target_imports is None:  # Default
-            result: dict[int, str] | dict[int, list[str]] = extractor.run()
+        if method == 'run':
+            assert extractor.run() == expected
         else:
-            result = extractor.run(  # `mypy` needs a bit of help here
-                assume_single_target_imports=cast(
-                    Literal[True, False],
-                    assume_single_target_imports,
-                ),
+            assert extractor.extract_all() == expected
+
+    for warning_expected, pattern, WarningType in checks:
+        regex = re.compile(pattern)
+        matches = [
+            msg for msg in warnings
+            if issubclass(msg.category, WarningType)
+            if regex.search(str(msg.message))
+        ]
+        if bool(matches) == warning_expected:
+            continue
+        if warning_expected:
+            # Note: Until Python 3.14 `WarningMessage.__repr__()` is
+            # terse; use `.__str__()` to show more context
+            raise AssertionError(
+                f'expected {WarningType.__name__} matching {pattern!r}, '
+                f'didn\'t get a match out of {len(warnings)} '
+                f'warnings captured: {[str(m) for m in warnings]!r}'
+            )
+        else:
+            raise AssertionError(
+                f'expected no {WarningType.__name__} matching {pattern!r}, '
+                f'got {len(matches)} match(es): {[str(m) for m in matches]!r}'
             )
 
-    assert result == expected
-    for check in checks:
-        check(warnings)
+
+def test_multitarget_import_transformation_executes() -> None:
+    """
+    Test the runtime behavior of the transformed AST, including:
+    - multiple targets in one import statement;
+    - aliases;
+    - selection of profiling targets;
+    - preservation of profiling-call order;
+    - passing the actual imported objects to the profiler.
+
+    See also:
+        Issue #433
+    """
+    from xml.etree.ElementTree import Element, dump, XMLParser
+
+    class RecordingProfiler:
+        """
+        Mock :py:class:`line_profiler.LineProfiler` object.
+        """
+        @classmethod
+        def add_imported_function_or_module(cls, obj) -> None:
+            cls.profiled_objects.append(obj)
+
+        profiled_objects: ClassVar[list[Any]] = []
+
+    input_module = ub.codeblock("""
+        import os, sys as system
+        from xml.etree.ElementTree import (  # `xml_dump` not profiled
+            Element, dump as xml_dump, XMLParser as Parser,
+        )
+    """)
+    with tempfile.TemporaryDirectory() as tmp:
+        fpath = ub.Path(tmp) / 'script.py'
+        fpath.write_text(input_module)
+        module_ast = AstTreeProfiler(
+            str(fpath),
+            [
+                'os',
+                'sys',
+                'xml.etree.ElementTree.Element',
+                'xml.etree.ElementTree.XMLParser',
+            ],
+            False,
+        ).profile()
+        namespace = {'profile': RecordingProfiler()}
+        code = compile(module_ast, str(fpath), 'exec')
+        exec(code, namespace)
+
+    assert RecordingProfiler.profiled_objects == [
+        os,
+        sys,
+        Element,
+        XMLParser,
+    ]
+    # Also verify that the aliases created by the original imports resolve
+    # to the same objects that were passed to the profiler.
+    assert namespace['system'] is sys
+    assert namespace['Element'] is Element
+    assert namespace['xml_dump'] is dump
+    assert namespace['Parser'] is XMLParser

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -8,7 +8,8 @@ import subprocess
 import sys
 import shlex
 import tempfile
-from typing import Any, ClassVar, Literal
+from collections.abc import Collection, Sequence
+from typing import Any, Literal
 from warnings import catch_warnings, WarningMessage
 
 import pytest
@@ -1271,7 +1272,7 @@ def test_multitarget_import_resolution(
      # a warning
      (['qux', 'quux'], {3: ['ham']}, 'extract_all',
       r'1 .* target.* dropped .* import \*.*'
-      r'- line 5: quux.*'),
+      r'- line 5: \* \(from quux\)'),
      # This doesn't result in a `UserWarning` for dropped targets,
      # because there is only one selected target on the multi-target
      # import line
@@ -1293,7 +1294,7 @@ def test_multitarget_import_resolution(
      # Same warning for `quux.*` as above for `.extract_all()`
      (['qux', 'quux'], {3: 'ham'}, 'run',
       r'1 .* target.* dropped .* import \*.*'
-      r'- line 5: quux.*')])
+      r'- line 5: \* \(from quux\)')])
 def test_profmod_extractor_multitarget_behavior(
     prof_mod: list[str],
     expected: dict[int, str] | dict[int, list[str]],
@@ -1381,6 +1382,22 @@ def test_profmod_extractor_multitarget_behavior(
                 result[loc[1]] = [imp.resolved_name for imp in imports]
             assert result == expected
 
+    _check_warnings(warnings, checks)
+
+
+def _check_warnings(
+    warnings: Sequence[WarningMessage],
+    checks: Collection[tuple[bool, str, type[Warning]]],
+) -> None:
+    """
+    With each tuple of ``warning_expected, msg, WarningType``, check
+    ``warnings`` that:
+
+    - If ``warning_expected = True``, there is at least 1 matching
+      warning.
+
+    - If ``warning_expected = False``, thers is no matching warning.
+    """
     for warning_expected, pattern, WarningType in checks:
         regex = re.compile(pattern)
         matches = [
@@ -1464,3 +1481,68 @@ def test_multitarget_import_transformation_executes() -> None:
     assert namespace['Element'] is Element
     assert namespace['xml_dump'] is dump
     assert namespace['Parser'] is XMLParser
+
+
+@pytest.mark.parametrize(
+    ('prof_mod', 'expected_targets', 'profile_imports', 'profile_whole_file',
+     'expect_warnings'),
+    [([], [], False, False, False),  # No-op case
+     # Whole-file rewriting, with and without import rewriting
+     ([], ['bar', 'baz'], True, True, True),
+     ([], [], False, True, False),
+     # No whole-file rewriting, bu we explicitly ask to profile the
+     # `spam.ham.*` import (which can't be done)
+     (['spam.ham'], [], False, False, True)])
+def test_handle_star_imports(
+    prof_mod: list[str],
+    expected_targets: Collection[Literal['bar', 'baz']],
+    profile_imports: bool,
+    profile_whole_file: bool,
+    expect_warnings: bool,
+) -> None:
+    """
+    Test that star-imports (``from ... import *``) don't cause
+    :py:meth:`AstTreeProfiler.profile` to choke, instead just issuing
+    warnings about ignoring them.
+
+    TODO: actually handle star-imports
+    """
+    code = ub.codeblock(
+        """
+        from foo import bar
+        from spam.ham import *
+        from foobar import baz
+
+
+        def func() -> None:
+            pass
+        """,
+    ).strip('\n')
+
+    targets_warning_pattern = 'profiling target.* dropped.*'
+    warning_checks = [(expect_warnings, targets_warning_pattern, UserWarning)]
+
+    re_checks: list[tuple[str, bool]] = []
+    re_checks.append((r'@profile\ndef func', profile_whole_file))
+    for target in 'bar', 'baz':
+        pattern = rf'add_imported_function_or_module\({target}\)'
+        re_checks.append((pattern, target in expected_targets))
+
+    with contextlib.ExitStack() as stack:
+        tmpdir = stack.enter_context(tempfile.TemporaryDirectory())
+        fpath = ub.Path(tmpdir) / 'script.py'
+        fpath.write_text(code)
+        if profile_whole_file:
+            prof_mod = [*prof_mod, str(fpath)]
+
+        warnings = stack.enter_context(catch_warnings(record=True))
+        rewriter = AstTreeProfiler(str(fpath), prof_mod, profile_imports)
+        module_ast = rewriter.profile()
+
+    # Check the issuance of warnings related to star-imports
+    _check_warnings(warnings, warning_checks)
+
+    # Check the profiling of other targets
+    output_module = ast.unparse(module_ast)
+    for pattern, expected in re_checks:
+        assert bool(re.search(pattern, output_module)) == expected

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -1260,12 +1260,18 @@ def test_multitarget_import_resolution(
 
 
 @pytest.mark.parametrize(
-    ('prof_mod', 'expected', 'method', 'expect_dropped_target_warning'),
+    ('prof_mod', 'expected', 'method', 'expect_warning'),
     [(['foo', 'foobar.ham'], {0: ['foo'], 2: ['ham']}, 'extract_all', None),
      (['baz', 'foobar'], {1: ['baz'], 2: ['spam', 'ham', 'jam']},
       'extract_all', None),
-     (['foobar', 'qux'], {2: ['spam', 'ham', 'jam'], 3: ['ham']},
+     (['foobar', 'qux', 'fred'],
+      {2: ['spam', 'ham', 'jam'], 3: ['ham'], 5: ['alexa', 'bob']},
       'extract_all', None),
+     # `from quux import *` cannot be profiled as of now, and results in
+     # a warning
+     (['qux', 'quux'], {3: ['ham']}, 'extract_all',
+      r'1 .* target.* dropped .* import \*.*'
+      r'- line 5: quux.*'),
      # This doesn't result in a `UserWarning` for dropped targets,
      # because there is only one selected target on the multi-target
      # import line
@@ -1273,16 +1279,26 @@ def test_multitarget_import_resolution(
      # This however results in the warning that `spam` and `ham` are
      # supposed to be profiled, but are dropped
      (['baz', 'foobar'], {1: 'baz', 2: 'jam'}, 'run',
-      r"2 .* target.* dropped .* \['ham', 'spam'\]"),
-     # And here we only warn against `spam`, because `foobar.ham` is
-     # shadowed by `qux.ham`
-     (['foobar', 'qux'], {2: 'jam', 3: 'ham'}, 'run',
-      r"1 .* target.* dropped .* \['spam'\]")])
+      '2 .* target.* dropped .* multi-target.*'
+      r'- line 3: ham \(= foobar.ham\), spam \(= foobar.spam\)'),
+     # - Despite how `foobar.ham` is shadowed by `qux.ham`, the former
+     #   is still dropped profiling; and so we include that in the
+     #   warning message, and also indicate the name's source
+     # - Note that the warning message is multiline because there are
+     #   dropped imports on multiple lines
+     (['foobar', 'qux', 'fred'], {2: 'jam', 3: 'ham', 5: 'bob'}, 'run',
+      '3 .* target.* dropped .* multi-target.*'
+      r'\n- line 3: ham \(= foobar.ham\), spam \(= foobar.spam\)'
+      r'\n- line 6: alexa \(= fred.alice\)'),
+     # Same warning for `quux.*` as above for `.extract_all()`
+     (['qux', 'quux'], {3: 'ham'}, 'run',
+      r'1 .* target.* dropped .* import \*.*'
+      r'- line 5: quux.*')])
 def test_profmod_extractor_multitarget_behavior(
     prof_mod: list[str],
     expected: dict[int, str] | dict[int, list[str]],
     method: Literal['extract_all', 'run'],
-    expect_dropped_target_warning: str | None,
+    expect_warning: str | None,
 ) -> None:
     """
     Test that :py:meth:`.ProfmodExtractor.extract_all` and
@@ -1297,13 +1313,18 @@ def test_profmod_extractor_multitarget_behavior(
           :py:meth:`.ProfmodExtractor.extract_all` instead
 
         - Issues a :py:class:`UserWarning` against dropped profiling
-          targets (if any)
+          targets because of multi-target import statements (if any)
+
+        - Issues a :py:class:`UserWarning` against dropped profiling
+          targets because of the currently unsupported
+          ``from ... import *`` statements (if any)
 
     ``.extract_all()`` (new method):
 
         - Returns ``dict[int, list[str]]``
 
-        - Does not result in the above warnings
+        - Does not result in the above warnings, except for the
+          ``from ... import *`` case
 
     See also:
         Issue #433
@@ -1314,14 +1335,16 @@ def test_profmod_extractor_multitarget_behavior(
         import baz
         from foobar import spam, ham, eggs as jam
         from qux import ham  # This shadows `foobar.ham` above
+        from quux import *  # Star-imports ignored for now
+        from fred import alice as alexa, bob
 
 
         def func() -> None:
             pass
         """,
-    )
+    ).strip('\n')
     depr_warning_pattern = 'run.* deprecated.* use .*extract_all'
-    targets_warning_pattern = 'profiling target.* dropped.* multi-target'
+    targets_warning_pattern = 'profiling target.* dropped.*'
     warnings: list[WarningMessage]
     checks: list[tuple[bool, str, type[Warning]]] = []
     # Check that the deprecation warning is only issued when using
@@ -1329,8 +1352,8 @@ def test_profmod_extractor_multitarget_behavior(
     checks.append((method == 'run', depr_warning_pattern, DeprecationWarning))
     # Check that the user warnin is only issued when a target has been
     # dropped (and not shadowed by a later import)
-    if expect_dropped_target_warning:
-        checks.append((True, expect_dropped_target_warning, UserWarning))
+    if expect_warning:
+        checks.append((True, expect_warning, UserWarning))
     else:
         checks.append((False, targets_warning_pattern, UserWarning))
 

--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -1321,7 +1321,10 @@ def test_profmod_extractor_multitarget_behavior(
 
     ``.extract_all()`` (new method):
 
-        - Returns ``dict[int, list[str]]``
+        - Returns \
+``dict[tuple[Literal['body'], int], list[ImportTarget]]``,
+          where ``ImportTarget.resolved_name`` is the name of the import
+          target in the namespace
 
         - Does not result in the above warnings, except for the
           ``from ... import *`` case
@@ -1367,7 +1370,16 @@ def test_profmod_extractor_multitarget_behavior(
         if method == 'run':
             assert extractor.run() == expected
         else:
-            assert extractor.extract_all() == expected
+            result: dict[int, list[str | None]] = {}
+            for loc, imports in extractor.extract_all().items():
+                # XXX: these assertions are true for the time being, but
+                # will become false when we extend to non-top-level
+                # import statements
+                assert len(loc) == 2
+                assert loc[0] == 'body'
+                assert isinstance(loc[1], int)
+                result[loc[1]] = [imp.resolved_name for imp in imports]
+            assert result == expected
 
     for warning_expected, pattern, WarningType in checks:
         regex = re.compile(pattern)


### PR DESCRIPTION
Closes #433.

Changes
----
- Refactored `line_profiler.autoprofile.profmod_extractor.ProfmodExtractor`:
  - `.run()` is now deprecated with a `DeprecationWarning`, and in addition a `UserWarning` when using it results in profiling targets being dropped from the output.
  - The new `.extract_all()` method returns instead `dict[tuple[str | int, ...], list[AstTreeProfiler]]` so that multi-target imports can be handled, and that we retain enough flexibility to handle other cases like star-imports and conditional imports via future extensions, without having to change the API like in this PR.
  - Added stop-gap handling for `from ... import *` statements (see item F4 in [`fable-review-fullrepo-2026-07-05.md`](https://github.com/TTsangSC/line_profiler/pull/5/changes#diff-dab6f6729ad85348119f9b4ec73b3dbe7b12ab2046ebfc713c2a5807ce94778b) in TTsangSC#5): instead of resulting in syntactically wrong `profile.add_imported_function_or_module(*)` statements, star-imports are now dropped from the output of `.run()` and `.extract_all()` with a warning.
- Introduced a new `line_profiler.autoprofile._import_targets.ImportTarget` class for hauling info around.
- `line_profiler.autoprofile.ast_tree_profiler.AstTreeProfiler` has been correspondingly updated to insert `prof.add_imported_function_or_module()` statements for each eligible target in multi-target imports.
- Added `ty` config line to `pyproject.toml` to guard against [v0.0.52's making redundant casts an error](https://github.com/pyutils/line_profiler/pull/431#issuecomment-4805884375).
- Added new tests in `tests/test_autoprofile.py` to verify the fixes:
  - `test_multitarget_import_resolution()` and `test_multitarget_import_transformation_execution()` check that `AstTreeProfiler.profile()` now correctly transforms ASTs with multi-target import statements.
  -  `test_profmod_extractor_multitarget_behavior()` checks that `ProfmodExtractor.run()`'s return type and warning issuance are as aforementioned.
  - `test_handle_star_imports()` checks that star-imports are correctly handled (read: ignored) by `AstTreeProfier.profile()`.